### PR TITLE
Allow disabling ECHI in vagrantfile

### DIFF
--- a/chef/atc/Vagrantfile
+++ b/chef/atc/Vagrantfile
@@ -49,6 +49,9 @@ def make_vm(config, opts)
         box.vm.network :forwarded_port, guest: 8000, host: 8080, auto_correct: true
         # extra interface
         box.vm.network :private_network, ip: opts.fetch(:priv_network, DFT_PRIV_NETWORK)
+        box.vm.provider "virtualbox" do |v|
+            v.customize ["modifyvm", :id, "--usbehci", opts.fetch(:usbehci, "on")]
+        end
         box.vm.provider "vmware_fusion" do |v, override|
             override.vm.box = "#{opts.fetch(:box, DFT_BOX)}_vmw"
             override.vm.box_url = opts.fetch(:box_url).gsub('virtualbox', 'vmware')


### PR DESCRIPTION
Several of the vagrant images I have tried crash on boot if USB EHCI is enabled. This patch allows you to disable EHCI by providing `:usbehci => 'off'` in the VM description.

This is pre-requisite for atc vagrant VMs a variety of platforms.
