### PR TITLE
Allow shaping a different IP through the URL

### DIFF
--- a/atc/django-atc-api/atc_api/serializers.py
+++ b/atc/django-atc-api/atc_api/serializers.py
@@ -148,8 +148,15 @@ class DeviceSerializer(ThriftSerializer):
     def validate_address(self, value):
         # 'address' is optional, if not specified, we default to the
         # querying IP
+        # `address` can be specified in 2 places: the URL or within the payload
+        # The payload has priority and will be accessible through `value`
+        # The value passed in the URL is accessible through the context
+
         if value is None or (isinstance(value, str) and len(value) == 0):
-            value = self._get_client_ip()
+            if self.context.get('address'):
+                value = self.context['address']
+            else:
+                value = self._get_client_ip()
         if not validate_ipaddr(value):
             raise serializers.ValidationError("Invalid IP address")
         return value

--- a/atc/django-atc-api/atc_api/views.py
+++ b/atc/django-atc-api/atc_api/views.py
@@ -76,7 +76,7 @@ class AtcApi(APIView):
         )
 
     @serviced
-    def post(self, request, service, format=None):
+    def post(self, request, service, address=None, format=None):
         ''''
         Set shaping for an IP. If address is None, defaults to
         the client IP
@@ -85,7 +85,7 @@ class AtcApi(APIView):
         setting_serializer = SettingSerializer(data=request.DATA)
         device_serializer = DeviceSerializer(
             data=request.DATA,
-            context={'request': request},
+            context={'request': request, 'address': address},
         )
         if not setting_serializer.is_valid():
             raise ParseError(detail=setting_serializer.errors)


### PR DESCRIPTION
The address to shape can be passed through a few locations: the payload or the URL. URL was being ignored so far. This fixes it by correctly passing the address through the view context.

GH: #11
