### PR TITLE
Change the default location of atcd's sqlite file.

### DIFF
--- a/atc/atcd/atcd/AtcdDBQueueTask.py
+++ b/atc/atcd/atcd/AtcdDBQueueTask.py
@@ -17,12 +17,12 @@ class AtcdDBQueueTask(QueueTask):
     OPT_PREFIX = 'sqlite'
     workers = 1
 
-    DEFAULT_SQLITE_FILE = '/var/lib/atc/atcd.db'
+    DEFAULT_SQLITE_FILE = '/var/lib/atcd.db'
 
     sqlite_file = option(
         default=DEFAULT_SQLITE_FILE,
         metavar='SQLITE_FILE',
-        help='Location to store the sqlite3 db',
+        help='Location to store the sqlite3 db [%(default)s]',
         name='file',
     )
 


### PR DESCRIPTION
Defaulting to `/var/lib/atc/atcd.db` will cause `atcd` to fail to start
if `/var/lib/atc` is not created before hand.
This will be an issue when people will install from source and we should
default to a directory that we know exists by default on a system.
