### PR TITLE
Force using /us/bin/env python, help with pip install from source

### DIFF
--- a/atc/atc_thrift/setup.cfg
+++ b/atc/atc_thrift/setup.cfg
@@ -1,2 +1,4 @@
 [wheel]
 universal = 1
+[build]
+executable = /usr/bin/env python

--- a/atc/atcd/setup.cfg
+++ b/atc/atcd/setup.cfg
@@ -1,2 +1,4 @@
 [wheel]
 universal = 1
+[build]
+executable = /usr/bin/env python

--- a/atc/django-atc-api/setup.cfg
+++ b/atc/django-atc-api/setup.cfg
@@ -1,2 +1,4 @@
 [wheel]
 universal = 1
+[build]
+executable = /usr/bin/env python

--- a/atc/django-atc-demo-ui/setup.cfg
+++ b/atc/django-atc-demo-ui/setup.cfg
@@ -1,2 +1,4 @@
 [wheel]
 universal = 1
+[build]
+executable = /usr/bin/env python

--- a/atc/django-atc-profile-storage/setup.cfg
+++ b/atc/django-atc-profile-storage/setup.cfg
@@ -1,2 +1,4 @@
 [wheel]
 universal = 1
+[build]
+executable = /usr/bin/env python


### PR DESCRIPTION
when installing from source, the shebang would not be properly setup because setuptools change it. This seems to make seems easier in that case, without breaking install from pip.
