### PR TITLE
run atcui-setup when provisioning a host.

### DIFF
--- a/chef/atc/recipes/atcui.rb
+++ b/chef/atc/recipes/atcui.rb
@@ -91,13 +91,26 @@ service 'atcui' do
   action [:enable, :start]
 end
 
-template '/usr/local/bin/atcui-setup' do
+atcui_setup_file = '/usr/local/bin/atcui-setup'
+template atcui_setup_file do
   source 'atcui-setup.erb'
   mode 0755
   owner atcui_user
   group actui_group
 end
 
+# Setup atcui if it is the first time it is installed
+atcui_configured_file = '/.atcui_configured'
+unless File.exist?(atcui_configured_file)
+  execute 'atcui setup' do
+    command atcui_setup_file
+    user atcui_user
+    group actui_group
+  end
+  file atcui_configured_file do
+    action :touch
+  end
+end
 # When running under vagrant, atcui depends on the mounts and will not start
 # unless those are up. The mount is happening after the system is up.
 # We can use udev to trigger starting/stopping atcui when amount/umount event

--- a/chef/atc/templates/default/atcui-setup.erb
+++ b/chef/atc/templates/default/atcui-setup.erb
@@ -9,7 +9,7 @@ USER="<%= node['atc']['atcui']['user'] %>"
 # Allow either $USER or root to run this script.
 if [ "$(whoami)" == "$USER" ] ; then
     USER=""
-elif [ "$EUID" == "0" ] ; then
+elif [ "$EUID" != "0" ] ; then
    echo -e "${RED}$0 must be run as root or $USER.${NC}"
    exit 1
 fi
@@ -28,9 +28,6 @@ function managepy() {
         sudo -u "$USER" /bin/bash -c "$C"
     fi
 }
-
-p "Syncing DB"
-managepy syncdb
 
 p "Migrating DB"
 managepy migrate


### PR DESCRIPTION
since django 1.7 (which is one of our requirements), syncdb has been
decoupled. `migrate` only sync the db state but does not prompt to
create a superuser.
https://docs.djangoproject.com/en/1.7/ref/django-admin/#migrate-app-label-migrationname
This can be ran without user interaction allowing us to automatically
set up our django app!
This also fixes a bug in atcui-setup that was not properly detecting if
it was run as root
