### PR TITLE
Enable PROXY_IPS check for shaping API calls

### DIFF
--- a/atc/django-atc-api/atc_api/serializers.py
+++ b/atc/django-atc-api/atc_api/serializers.py
@@ -7,6 +7,7 @@
 #  of patent rights can be found in the PATENTS file in the same directory.
 #
 #
+from atc_api.settings import atc_api_settings
 from atc_thrift.ttypes import Corruption
 from atc_thrift.ttypes import Delay
 from atc_thrift.ttypes import Loss
@@ -178,6 +179,8 @@ class DeviceSerializer(ThriftSerializer):
         '''Return the real IP of a client even when using a proxy'''
         request = self.context['request']
         if 'HTTP_X_REAL_IP' in request.META:
+            if request.META['REMOTE_ADDR'] not in atc_api_settings.PROXY_IPS:
+                raise ValueError('HTTP_X_REAL_IP set by non-proxy')
             return request.META['HTTP_X_REAL_IP']
         else:
             return request.META['REMOTE_ADDR']

--- a/atc/django-atc-api/atc_api/settings.py
+++ b/atc/django-atc-api/atc_api/settings.py
@@ -15,6 +15,7 @@ ATC_API = {
     'ATCD_HOST': 'localhost',
     'ATCD_PORT': 9090,
     'DEFAULT_TC_TIMEOUT': 24 * 60 * 60,
+    'PROXY_IPS': ['127.0.0.1'],
 }
 
 This module provides the `atc_api_settings` object, that is used to access
@@ -31,7 +32,7 @@ DEFAULTS = {
     'ATCD_PORT': 9090,
     # Default timeout is a day in seconds
     'DEFAULT_TC_TIMEOUT': 24 * 60 * 60,
-    'PROXY_IPS': '127.0.0.1',
+    'PROXY_IPS': ['127.0.0.1'],
 }
 
 


### PR DESCRIPTION
Also makes PROXY_IPS default to ['127.0.0.1'] instead of '127.0.0.1'.
End results is the same as '127.0.0.1' in '127.0.0.1' is True, but it is
more correct.
