### PR TITLE
added utils.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@
 # Described fully in `tests/Vagrantfile`.
 TESTVMS = gateway client server
 
+FLAKE=python -m flake8
+PEP=pep8
+
 
 # By default, we just lint since we want this to be **fast**.
 # In the future when unit testing becomes better this should run quick tests.
@@ -64,9 +67,9 @@ chef_lint:
 
 .PHONY: python_lint
 python_lint:
-	pep8 atc
-	flake8 atc
-	flake8 tests/
+	$(PEP) atc
+	$(FLAKE) atc
+	$(FLAKE) tests/
 
 
 # Performs setup, runs the tests, then cleans up.

--- a/atc/django-atc-api/atc_api/serializers.py
+++ b/atc/django-atc-api/atc_api/serializers.py
@@ -7,7 +7,7 @@
 #  of patent rights can be found in the PATENTS file in the same directory.
 #
 #
-from atc_api.settings import atc_api_settings
+from atc_api.utils import get_client_ip
 from atc_thrift.ttypes import Corruption
 from atc_thrift.ttypes import Delay
 from atc_thrift.ttypes import Loss
@@ -176,11 +176,4 @@ class DeviceSerializer(ThriftSerializer):
         return self._get_client_ip()
 
     def _get_client_ip(self):
-        '''Return the real IP of a client even when using a proxy'''
-        request = self.context['request']
-        if 'HTTP_X_REAL_IP' in request.META:
-            if request.META['REMOTE_ADDR'] not in atc_api_settings.PROXY_IPS:
-                raise ValueError('HTTP_X_REAL_IP set by non-proxy')
-            return request.META['HTTP_X_REAL_IP']
-        else:
-            return request.META['REMOTE_ADDR']
+        return get_client_ip(self.context['request'])

--- a/atc/django-atc-api/atc_api/utils.py
+++ b/atc/django-atc-api/atc_api/utils.py
@@ -1,0 +1,24 @@
+#
+#  Copyright (c) 2015, Facebook, Inc.
+#  All rights reserved.
+#
+#  This source code is licensed under the BSD-style license found in the
+#  LICENSE file in the root directory of this source tree. An additional grant
+#  of patent rights can be found in the PATENTS file in the same directory.
+#
+#
+
+from atc_api.settings import atc_api_settings
+
+
+def get_client_ip(request):
+    '''
+    Return the real IP of a client even when using a proxy
+    '''
+
+    if 'HTTP_X_REAL_IP' in request.META:
+        if request.META['REMOTE_ADDR'] not in atc_api_settings.PROXY_IPS:
+            raise ValueError('HTTP_X_REAL_IP set by non-proxy')
+        return request.META['HTTP_X_REAL_IP']
+    else:
+        return request.META['REMOTE_ADDR']


### PR DESCRIPTION
utils.py has `get_client_ip` which abstracts out two different methods previously existing in `views.py` and `serializers.py`

fixes #52 