### PR TITLE
Auth UI

### DIFF
--- a/atc/django-atc-api/atc_api/static/js/atc-api.js
+++ b/atc/django-atc-api/atc_api/static/js/atc-api.js
@@ -69,6 +69,17 @@ AtcRestClient.prototype.getCurrentShaping = function (callback) {
     this.api_call('GET', 'shape', callback);
 };
 
+AtcRestClient.prototype.getToken = function (callback) {
+    this.api_call('GET', 'token', callback);
+};
+
+AtcRestClient.prototype.getAuthInfo = function (callback) {
+    this.api_call('GET', 'auth', callback);
+};
+
+AtcRestClient.prototype.updateAuthInfo = function (address, data, callback) {
+    this.api_call('POST', 'auth/'.concat(address), callback, data);
+};
 
 function AtcSettings () {
     this.defaults = {

--- a/atc/django-atc-api/atc_api/utils.py
+++ b/atc/django-atc-api/atc_api/utils.py
@@ -15,7 +15,6 @@ def get_client_ip(request):
     '''
     Return the real IP of a client even when using a proxy
     '''
-
     if 'HTTP_X_REAL_IP' in request.META:
         if request.META['REMOTE_ADDR'] not in atc_api_settings.PROXY_IPS:
             raise ValueError('HTTP_X_REAL_IP set by non-proxy')

--- a/atc/django-atc-demo-ui/atc_demo_ui/static/css/atc.css
+++ b/atc/django-atc-demo-ui/atc_demo_ui/static/css/atc.css
@@ -18,3 +18,7 @@ We're not using anchors, so make sure users know they can click on panel headers
 .panel-heading {
     cursor: pointer;
 }
+
+.error-timer {
+    text-align: right;
+}

--- a/atc/django-atc-demo-ui/atc_demo_ui/static/css/atc.css
+++ b/atc/django-atc-demo-ui/atc_demo_ui/static/css/atc.css
@@ -11,3 +11,10 @@
     margin: 10px;
     padding: 5px;
 }
+
+/*
+We're not using anchors, so make sure users know they can click on panel headers
+*/
+.panel-heading {
+    cursor: pointer;
+}

--- a/atc/django-atc-demo-ui/atc_demo_ui/static/js/atc-auth.js
+++ b/atc/django-atc-demo-ui/atc_demo_ui/static/js/atc-auth.js
@@ -1,0 +1,197 @@
+/** @jsx React.DOM */
+/**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+
+var TokenFrame = React.createClass({
+  getInitialState: function() {
+    this.oos_notified = false;
+    return {
+      token: null,
+      valid_until: null,
+    };
+  },
+
+  componentDidMount: function() {
+    this.getToken();
+    this.interval = setInterval(this.getToken, 3000);
+  },
+
+  componentWillUnmount: function() {
+    if (this.interval != null) {
+      clearInterval(this.interval);
+    }
+  },
+
+  getToken: function() {
+    this.props.client.getToken(function (result) {
+      if (result.status >= 200 && result.status < 300) {
+        valid_until = new Date(result.json.valid_until*1000).toLocaleTimeString();
+        if (result.json.valid_until - Math.floor(new Date().getTime() / 1000) < 0) {
+          if (!this.oos_notified) {
+            this.props.notify("warn", "The time on the ATC server is out of sync.");
+            this.oos_notified = true;
+          }
+        }
+        this.setState({
+          token: result.json,
+        });
+      } else {
+        this.props.notify("error", "Could not fetch current token: " + result.json);
+        this.setState({
+          token: null,
+        });
+      }
+    }.bind(this));
+  },
+
+  render: function() {
+    if (this.state.token == null) {
+      return null;
+    }
+
+    return (
+      <div className="col-md-6">
+        <div>
+          <h4>This Machine&#39;s Token: <b>{this.state.token.token}</b></h4>
+          <b>Valid Until:</b> {valid_until}
+          <h4>This Machine&#39; Address: {this.state.token.address}</h4>
+        </div>
+      </div>
+    );
+  },
+});
+
+var AuthFrame = React.createClass({
+  getInitialState: function() {
+    return {
+      auth: null,
+      token: null,
+      address: null,
+    };
+  },
+
+  componentDidMount: function() {
+    this.getAuthInfo();
+  },
+
+  updateToken: function(event) {
+    this.setState({token: event.target.value});
+  },
+
+  updateAddress: function(event) {
+    this.setState({address: event.target.value});
+  },
+
+  getAuthInfo: function() {
+    this.props.client.getAuthInfo(function (result) {
+      if (result.status >= 200 && result.status < 300) {
+        this.setState({
+          auth: result.json,
+          address: result.json.address,
+        });
+      } else {
+        this.props.notify("error", "Could not fetch auth info: " + result.json);
+        this.setState({
+          auth: null,
+          address: null,
+        });
+      }
+    }.bind(this));
+  },
+
+  updateAuth: function() {
+    var failed = false;
+    if (this.state.address == null || this.state.address == "") {
+      this.props.notify("error", "You must enter an address");
+      failed = true;
+    }
+    if (this.state.token == null || this.state.token == "") {
+      this.props.notify("error", "You must enter a token");
+      failed = true;
+    }
+    if (failed) {
+      return;
+    }
+    this.props.client.updateAuthInfo(this.state.address, {token: Number(this.state.token)}, function(result) {
+      if (result.status >= 200 && result.status < 300) {
+        console.log("Authorizing:", result.json);
+        this.props.notify("success", "You can now shape " + result.json.controlled_ip);
+      } else {
+        this.props.notify("error", "Could not update auth info: ", result.json);
+      }
+    }.bind(this));
+  },
+
+  render: function() {
+    if (this.state.auth == null) {
+      return null;
+    }
+
+    var controlled_ips = null;
+    if (this.state.auth.controlled_ips.length > 0) {
+      controlled_ips = this.state.auth.controlled_ips.map(function (addr) {
+        return (
+          <li><pre><code>{addr}</code></pre></li>
+        );
+      });
+      controlled_ips = (
+        <ul>{controlled_ips}</ul>
+      );
+    } else {
+      controlled_ips = (
+        <i>No Controlled Machines</i>
+      );
+    }
+
+    return (
+      <div className="col-md-6">
+        <div>
+          <h4>Machines You Can Shape:</h4>
+          {controlled_ips}
+          <p>
+          <b>Note:</b> A machine is always allowed to shape itself.
+          </p>
+
+          <h4>Authorize a New Machine:</h4>
+          <label className="control-label">Address:</label>
+          <input type="text" className="form-control" placeholder="127.0.0.1" onChange={this.updateAddress}/>
+          <label className="control-label">Token:</label>
+          <input type="number" className="form-control" placeholder="12345" onChange={this.updateToken}/>
+          <button className="btn btn-success" onClick={this.updateAuth}>Authorize</button>
+        </div>
+      </div>
+    );
+  },
+});
+
+var AuthPanel = React.createClass({
+  render: function() {
+    return (
+      <div className="panel-group" id="accordion3" role="tablist" aria-multiselectable="false">
+        <div className="panel panel-default">
+          <div className="panel-heading" data-toggle="collapse" data-parent="#accordion3" href="#collapseAuth" aria-expanded="false" aria-controls="collapseAuth">
+              <h4 className="panel-title">
+                  Authentication
+              </h4>
+          </div>
+          <div id="collapseAuth" className="panel-collapse collapse" role="tabpanel">
+            <div className="panel-body">
+
+              <div className="row">
+                <AuthFrame client={this.props.client} notify={this.props.notify} />
+                <TokenFrame client={this.props.client} notify={this.props.notify} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+})

--- a/atc/django-atc-demo-ui/atc_demo_ui/static/js/atc-profiles.js
+++ b/atc/django-atc-demo-ui/atc_demo_ui/static/js/atc-profiles.js
@@ -1,0 +1,158 @@
+/** @jsx React.DOM */
+/**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+
+var Profile = React.createClass({
+  getInitialState: function() {
+    return {
+      name: "",
+    };
+  },
+
+  handleClick: function() {
+    this.props.link_state("settings").requestChange(
+      new AtcSettings().mergeWithDefaultSettings(this.props.profile.content)
+    );
+  },
+
+  updateName: function(event) {
+    this.setState({name: event.target.value});
+  },
+
+  removeProfile: function() {
+    this.props.link_state("client").value.delete_profile(handleAPI(this.props.refreshProfiles, this.props.notify), this.props.profile.id);
+  },
+
+  render: function () {
+    return (
+      <div className="list-group-item row">
+        <span className="col-sm-6 text-center vcenter"><kbd>{this.props.profile.name}</kbd></span>
+        <span className="col-sm-2 text-center vcenter">{this.props.profile.content.up.rate} kbps</span>
+        <span className="col-sm-2 text-center vcenter">{this.props.profile.content.down.rate} kbps</span>
+        <button className="col-sm-1 btn btn-info vcenter" onClick={this.handleClick}>Select</button>
+        <button className="col-sm-1 btn btn-danger vcenter" onClick={this.removeProfile}>Delete</button>
+      </div>);
+  }
+});
+
+
+var ProfileList = React.createClass({
+  render: function() {
+    if (this.props.profiles.length == 0) {
+      return false;
+    }
+
+    var profileNodes = this.props.profiles.map(function (profile) {
+      return (
+        <Profile refreshProfiles={this.props.refreshProfiles} link_state={this.props.link_state} action='delete' profile={profile} notify={this.props.notify} />
+      );
+    }.bind(this));
+
+    return (
+      <div>
+        <h4>Existing Profiles</h4>
+        <p>
+          Select a profile from the list below to use it.
+        </p>
+        <div className="list-group">
+          <div className="list-group-item row">
+            <span className="col-sm-6 text-center vcenter"><b>Name</b></span>
+            <span className="col-sm-2 text-center vcenter"><b>Up Rate</b></span>
+            <span className="col-sm-2 text-center vcenter"><b>Down Rate</b></span>
+            <span className="col-sm-1 text-center vcenter"></span>
+            <span className="col-sm-1 text-center vcenter"></span>
+          </div>
+
+          {profileNodes}
+        </div>
+      </div>
+    );
+  }
+});
+
+
+var CreateProfileWidget = React.createClass({
+  getInitialState: function() {
+    return {
+      name: ""
+    };
+  },
+
+  updateName: function(event) {
+    this.setState({name: event.target.value});
+  },
+
+  newProfile: function() {
+    var failed = false;
+    var settings = this.props.link_state('settings').value;
+    if (settings.down.rate == null &&
+      settings.up.rate == null) {
+      this.props.notify("error", "You must enter shaping settings below.");
+      failed = true;
+    }
+    if (this.state.name == "") {
+      this.props.notify("error", "You must give the new profile a name.");
+      failed = true;
+    }
+    if (failed) {
+      return;
+    }
+
+    var addProfile = function() {
+      this.setState({
+        name: "",
+      });
+      this.props.refreshProfiles();
+    }.bind(this);
+
+    var profile = {
+      name: this.state.name,
+      content: settings
+    };
+    this.props.link_state("client").value.new_profile(handleAPI(addProfile, this.props.notify), profile);
+  },
+
+  render: function() {
+    return (
+      <div>
+        <h4>New Profile</h4>
+        <p>
+          Enter a name and click "Create" to save a new profile with the settings under "Shaping Settings" below.
+        </p>
+        <input type="text" className="form-control" placeholder="Profile Name" onChange={this.updateName}/>
+        <button className="col-sm-2 btn btn-success" onClick={this.newProfile}>Create</button>
+      </div>
+    );
+  },
+});
+
+
+var ProfilePanel = React.createClass({
+  render: function () {
+    return (
+      <div className="panel-group" id="accordion1" role="tablist" aria-multiselectable="false">
+        <div className="panel panel-default">
+          <div className="panel-heading" data-toggle="collapse" data-parent="#accordion1" href="#collapseProfiles" aria-expanded="false" aria-controls="collapseProfiles">
+            <h3 className="panel-title">
+              Profiles
+            </h3>
+          </div>
+          <div id="collapseProfiles" className="panel-collapse collapse" role="tabpanel">
+            <div className="panel-body">
+              <ProfileList refreshProfiles={this.props.refreshProfiles} link_state={this.props.link_state} profiles={this.props.profiles} notify={this.props.notify}/>
+
+              <CreateProfileWidget refreshProfiles={this.props.refreshProfiles} link_state={this.props.link_state} notify={this.props.notify}/>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+});

--- a/atc/django-atc-demo-ui/atc_demo_ui/static/js/atc-shaping.js
+++ b/atc/django-atc-demo-ui/atc_demo_ui/static/js/atc-shaping.js
@@ -1,0 +1,184 @@
+/** @jsx React.DOM */
+/**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+
+ var ShapingButton = React.createClass({
+  render: function () {
+    button_values = [
+      {
+        message: "ATC is not running",
+        css: "warning",
+      },
+      {
+        message: "Turn Off",
+        css: "danger",
+      },
+      {
+        message: "Turn On",
+        css: "primary",
+      },
+      {
+        message: "Update Shaping",
+        css: "success",
+      },
+    ];
+
+    content = button_values[this.props.status];
+    return (
+      <button type="button" id={this.props.id} className={"btn btn-" + content.css} disabled={this.props.status == atc_status.OFFLINE} onClick={this.props.onClick}>
+        {content.message}
+      </button>
+    );
+  }
+});
+
+
+var LinkShapingNumberSetting = React.createClass({
+  mixins: [IdentifyableObject],
+  render: function () {
+    id = this.getIdentifier();
+    link_state = this.props.link_state("settings_" + id);
+    return (
+      <div className="form-group">
+        <label htmlFor={id} className="col-sm-3 control-label">{this.props.text}</label>
+        <div className="col-sm-9">
+          <input type="number" defaultValue={link_state.value} className="form-control" id={id} placeholder={this.props.placeholder} min="0" max={this.props.max_value} valueLink={link_state} />
+        </div>
+      </div>
+    )
+  }
+});
+
+
+var LinkShapingPercentSetting = React.createClass({
+  render: function () {
+    return (
+      <LinkShapingNumberSetting input_id={this.props.input_id} text={this.props.text} placeholder="In %" link_state={this.props.link_state} max_value="100" />
+    )
+  }
+});
+
+
+var CollapseableInputList = React.createClass({
+  render: function () {
+    return (
+      <fieldset className="accordion-group">
+        <legend>{this.props.text}</legend>
+        {this.props.children}
+      </fieldset>
+    );
+  }
+});
+
+
+var CollapseableInputGroup = React.createClass({
+  mixins: [IdentifyableObject],
+  getInitialState: function () {
+    return {collapsed: true};
+  },
+
+  handleClick: function (e) {
+    this.setState({collapsed: !this.state.collapsed})
+  },
+
+  render: function () {
+    id = this.getIdentifier();
+    var text = this.state.collapsed ? 'Show more' : 'Show less';
+    return (
+      <div>
+        <div className="accordion-heading">
+          <a className="accordion-toggle" data-toggle="collapse" data-target={"#" + id} href="#" onClick={this.handleClick}>{text}</a>
+        </div>
+        <div className="accordion-body collapse" id={id}>
+          <div className="accordion-inner">
+            {this.props.children}
+          </div>
+        </div>
+      </div>
+    );
+  }
+});
+
+
+var LinkShapingSettings = React.createClass({
+  render: function () {
+    d = this.props.direction;
+    return (
+      <div>
+        <h4>{capitalizeFirstLetter(d) + "link"}:</h4>
+        <div className="well" id={d + "_well"}>
+          <div className="form-horizontal accordion">
+            <CollapseableInputList text="Bandwidth">
+              <LinkShapingNumberSetting params={[d, "rate"]} text="Rate" placeholder="in kbps" link_state={this.props.link_state} />
+            </CollapseableInputList>
+            <CollapseableInputList text="Latency">
+              <LinkShapingNumberSetting params={[d, "delay", "delay"]} text="Delay" placeholder="in ms" link_state={this.props.link_state} />
+              <CollapseableInputGroup params={[d, "delay", "collapse"]}>
+                <LinkShapingNumberSetting params={[d, "delay","jitter"]} text="Jitter" placeholder="in %" link_state={this.props.link_state} />
+                <LinkShapingNumberSetting params={[d, "delay", "correlation"]} text="Correlation" placeholder="in %" link_state={this.props.link_state} />
+              </CollapseableInputGroup>
+            </CollapseableInputList>
+            <CollapseableInputList text="Loss">
+              <LinkShapingNumberSetting params={[d, "loss", "percentage"]} text="Percentage" placeholder="in %" link_state={this.props.link_state} />
+              <CollapseableInputGroup params={[d, "loss", "collapse"]}>
+                <LinkShapingNumberSetting params={[d, "loss", "correlation"]} text="Correlation" placeholder="in %" link_state={this.props.link_state} />
+              </CollapseableInputGroup>
+            </CollapseableInputList>
+            <CollapseableInputList text="Corruption">
+              <LinkShapingNumberSetting params={[d, "corruption", "percentage"]} text="Percentage" placeholder="in %" link_state={this.props.link_state} />
+              <CollapseableInputGroup params={[d, "corruption", "collapse"]}>
+                <LinkShapingNumberSetting params={[d, "corruption", "correlation"]} text="Correlation" placeholder="in %" link_state={this.props.link_state} />
+              </CollapseableInputGroup>
+            </CollapseableInputList>
+            <CollapseableInputList text="Reorder">
+              <LinkShapingNumberSetting params={[d, "reorder", "percentage"]} text="Percentage" placeholder="in %" link_state={this.props.link_state} />
+              <CollapseableInputGroup params={[d, "reorder", "collapse"]}>
+                <LinkShapingNumberSetting params={[d, "reorder", "correlation"]} text="Correlation" placeholder="in %" link_state={this.props.link_state} />
+                <LinkShapingNumberSetting params={[d, "reorder", "gap"]} text="Gap" placeholder="integer" link_state={this.props.link_state}/>
+              </CollapseableInputGroup>
+            </CollapseableInputList>
+          </div>
+        </div>
+      </div>
+    );
+  }
+});
+
+
+var ShapingSettings = React.createClass({
+  render: function () {
+    return (
+      <div className="panel-group" id="accordion2" role="tablist" aria-multiselectable="false">
+        <div className="panel panel-default">
+          <div className="panel-heading" data-toggle="collapse" data-parent="#accordion2" href="#collapseShaping" aria-expanded="false" aria-controls="collapseShaping">
+              <h4 className="panel-title">
+                  Shaping Settings
+              </h4>
+          </div>
+          <div id="collapseShaping" className="panel-collapse collapse in" role="tabpanel">
+            <div className="panel-body">
+              <div className="row">
+                <div className="col-md-6">
+                  <LinkShapingSettings direction="up" link_state={this.props.link_state} />
+                </div>
+                <div className="col-md-6">
+                  <LinkShapingSettings direction="down" link_state={this.props.link_state} />
+                </div>
+              </div>
+
+              <JSONView json={this.props.before} label="Before:" />
+              <JSONView json={this.props.after} label="After:" />
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+});

--- a/atc/django-atc-demo-ui/atc_demo_ui/static/js/atc-utils.js
+++ b/atc/django-atc-demo-ui/atc_demo_ui/static/js/atc-utils.js
@@ -1,0 +1,117 @@
+/** @jsx React.DOM */
+/**
+ * Copyright (c) 2014, Facebook, Inc.
+ * All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+
+var JSONView = React.createClass({
+  render: function() {
+    return (
+      <div className="col-md-6">
+      <h4>{this.props.label}</h4>
+      <pre>
+        { JSON.stringify(this.props.json, null, 2) }
+      </pre>
+      </div>
+    );
+  }
+});
+
+
+function capitalizeFirstLetter(s) {
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+
+/** https://gist.github.com/NV/8622188 **/
+/**
+ * RecursiveLinkStateMixin is a LinkState alternative that can update keys in
+ * a dictionnary recursively.
+ * You can either give it a string of keys separated by a underscore (_)
+ * or a list of keys
+ */
+var RecursiveLinkStateMixin = {
+  linkState: function (path) {
+    function setPath (obj, path, value) {
+      var leaf = resolvePath(obj, path);
+      leaf.obj[leaf.key] = value;
+    }
+
+    function getPath (obj, path) {
+      var leaf = resolvePath(obj, path);
+      return leaf.obj[leaf.key];
+    }
+
+    function resolvePath (obj, keys) {
+      if (typeof keys === 'string') {
+        keys = keys.split('_');
+      }
+      var lastIndex = keys.length - 1;
+      var current = obj;
+      for (var i = 0; i < lastIndex; i++) {
+        var key = keys[i];
+        current = current[key];
+      }
+      return {
+        obj: current,
+        key: keys[lastIndex]
+      };
+    }
+
+    return {
+      value: getPath(this.state, path),
+      requestChange: function(newValue) {
+        setPath(this.state, path, newValue);
+        this.forceUpdate();
+      }.bind(this)
+    };
+  }
+};
+
+
+var IdentifyableObject = {
+  getIdentifier: function () {
+    return this.props.params.join('_');
+  },
+};
+
+
+function handleAPI(callback, notify) {
+  return function(rc) {
+    /* 2XX error codes are OK */
+    if (rc.status < 300 && rc.status >= 200) {
+      if (callback !== undefined) {
+        callback(rc);
+      }  
+    } else {
+      err = false;
+      t = typeof rc.json;
+      if (t === 'undefined') {
+        err = "Could not complete request due to server error."
+      } else if (t === 'string') {
+        s = rc.json;
+
+        /* trim off the first line */
+        s = s.trim().substring(s.length, s.indexOf('\n'));
+
+        /* take the second line as the error message */
+        s = s.trim().substring(0, s.indexOf('\n'));
+
+        err = s;
+      } else if (t === 'object') {
+        err = rc.json.detail;
+      }
+
+      if (err) {
+        notify('error', err);
+      } else {
+        console.log("Not sure what to do with error value " + t + " '" + rc.json + "'");
+      }
+    }
+  }
+}

--- a/atc/django-atc-demo-ui/atc_demo_ui/static/js/atc.js
+++ b/atc/django-atc-demo-ui/atc_demo_ui/static/js/atc.js
@@ -8,58 +8,8 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  */
 
+var ERROR_EXPIRY = 10000;
 
-
-/** https://gist.github.com/NV/8622188 **/
-/**
- * RecursiveLinkStateMixin is a LinkState alternative that can update keys in
- * a dictionnary recursively.
- * You can either give it a string of keys separated by a underscore (_)
- * or a list of keys
- */
-var RecursiveLinkStateMixin = {
-  linkState: function (path) {
-    function setPath (obj, path, value) {
-      var leaf = resolvePath(obj, path);
-      leaf.obj[leaf.key] = value;
-    }
-
-    function getPath (obj, path) {
-      var leaf = resolvePath(obj, path);
-      return leaf.obj[leaf.key];
-    }
-
-    function resolvePath (obj, keys) {
-      if (typeof keys === 'string') {
-        keys = keys.split('_');
-      }
-      var lastIndex = keys.length - 1;
-      var current = obj;
-      for (var i = 0; i < lastIndex; i++) {
-        var key = keys[i];
-        current = current[key];
-      }
-      return {
-        obj: current,
-        key: keys[lastIndex]
-      };
-    }
-
-    return {
-      value: getPath(this.state, path),
-      requestChange: function(newValue) {
-        setPath(this.state, path, newValue);
-        this.forceUpdate();
-      }.bind(this)
-    };
-  }
-};
-
-var IdentifyableObject = {
-  getIdentifier: function () {
-    return this.props.params.join('_');
-  },
-};
 
 var atc_status = {
   OFFLINE: 0,
@@ -69,398 +19,44 @@ var atc_status = {
 };
 
 
-function handleAPI(link_state, callback) {
-  return function(rc) {
-    /* 2XX error codes are OK */
-    if (rc.status < 300 && rc.status >= 200) {
-      if (callback !== undefined) {
-        callback(rc);
-      }  
-    } else {
-      err = false;
-      t = typeof rc.json;
-      if (t === 'undefined') {
-        err = {
-          detail: "Could not complete request due to server error.",
-        }
-      } else if (t === 'string') {
-        s = rc.json
+var NOTIFICATION_TYPES = new Map([
+  ["error", "danger"],
+  ["info", "info"],
+  ["warn", "warning"],
+  ["success", "success"],
+]);
 
-        /* trim off the first line */
-        s = s.trim().substring(s.length, s.indexOf('\n'))
 
-        /* take the second line as the error message */
-        s = s.trim().substring(0, s.indexOf('\n'))
-
-        err = {
-          detail: s,
-        };
-      } else if (t === 'object') {
-        err = rc.json;
-      }
-
-      if (err) {
-        link_state('errorMsg').requestChange(err);
-      } else {
-        console.log("Not sure what to do with error value " + t + " '" + rc.json + "'");
-      }
-    }
-  }
-}
-
-function capitalizeFirstLetter(s) {
-    return s.charAt(0).toUpperCase() + s.slice(1);
-}
-
-var ShapingButton = React.createClass({
+var NotificationPanel = React.createClass({
   render: function () {
-    button_values = [
-      {
-        message: "ATC is not running",
-        css: "warning",
-      },
-      {
-        message: "Turn Off",
-        css: "danger",
-      },
-      {
-        message: "Turn On",
-        css: "primary",
-      },
-      {
-        message: "Update Shaping",
-        css: "success",
-      },
-    ];
-
-    content = button_values[this.props.status];
-    return (
-      <button type="button" id={this.props.id} className={"btn btn-" + content.css} disabled={this.props.status == atc_status.OFFLINE} onClick={this.props.onClick}>
-        {content.message}
-      </button>
-    );
-  }
-});
-
-
-var LinkShapingNumberSetting = React.createClass({
-  mixins: [IdentifyableObject],
-  render: function () {
-    id = this.getIdentifier();
-    link_state = this.props.link_state("settings_" + id);
-    return (
-      <div className="form-group">
-        <label htmlFor={id} className="col-sm-3 control-label">{this.props.text}</label>
-        <div className="col-sm-9">
-          <input type="number" defaultValue={link_state.value} className="form-control" id={id} placeholder={this.props.placeholder} min="0" max={this.props.max_value} valueLink={link_state} />
-        </div>
-      </div>
-    )
-  }
-});
-
-
-var LinkShapingPercentSetting = React.createClass({
-  render: function () {
-    return (
-      <LinkShapingNumberSetting input_id={this.props.input_id} text={this.props.text} placeholder="In %" link_state={this.props.link_state} max_value="100" />
-    )
-  }
-});
-
-
-var CollapseableInputList = React.createClass({
-  render: function () {
-    return (
-      <fieldset className="accordion-group">
-        <legend>{this.props.text}</legend>
-        {this.props.children}
-      </fieldset>
-    );
-  }
-});
-
-
-var CollapseableInputGroup = React.createClass({
-  mixins: [IdentifyableObject],
-  getInitialState: function () {
-    return {collapsed: true};
-  },
-
-  handleClick: function (e) {
-    this.setState({collapsed: !this.state.collapsed})
-  },
-
-  render: function () {
-    id = this.getIdentifier();
-    var text = this.state.collapsed ? 'Show more' : 'Show less';
-    return (
-      <div>
-        <div className="accordion-heading">
-          <a className="accordion-toggle" data-toggle="collapse" data-target={"#" + id} href="#" onClick={this.handleClick}>{text}</a>
-        </div>
-        <div className="accordion-body collapse" id={id}>
-          <div className="accordion-inner">
-            {this.props.children}
-          </div>
-        </div>
-      </div>
-    );
-  }
-});
-
-
-var LinkShapingSettings = React.createClass({
-  render: function () {
-    d = this.props.direction;
-    return (
-      <div>
-        <h4>{capitalizeFirstLetter(d) + "link"}:</h4>
-        <div className="well" id={d + "_well"}>
-          <div className="form-horizontal accordion">
-            <CollapseableInputList text="Bandwidth">
-              <LinkShapingNumberSetting params={[d, "rate"]} text="Rate" placeholder="in kbps" link_state={this.props.link_state} />
-            </CollapseableInputList>
-            <CollapseableInputList text="Latency">
-              <LinkShapingNumberSetting params={[d, "delay", "delay"]} text="Delay" placeholder="in ms" link_state={this.props.link_state} />
-              <CollapseableInputGroup params={[d, "delay", "collapse"]}>
-                <LinkShapingNumberSetting params={[d, "delay","jitter"]} text="Jitter" placeholder="in %" link_state={this.props.link_state} />
-                <LinkShapingNumberSetting params={[d, "delay", "correlation"]} text="Correlation" placeholder="in %" link_state={this.props.link_state} />
-              </CollapseableInputGroup>
-            </CollapseableInputList>
-            <CollapseableInputList text="Loss">
-              <LinkShapingNumberSetting params={[d, "loss", "percentage"]} text="Percentage" placeholder="in %" link_state={this.props.link_state} />
-              <CollapseableInputGroup params={[d, "loss", "collapse"]}>
-                <LinkShapingNumberSetting params={[d, "loss", "correlation"]} text="Correlation" placeholder="in %" link_state={this.props.link_state} />
-              </CollapseableInputGroup>
-            </CollapseableInputList>
-            <CollapseableInputList text="Corruption">
-              <LinkShapingNumberSetting params={[d, "corruption", "percentage"]} text="Percentage" placeholder="in %" link_state={this.props.link_state} />
-              <CollapseableInputGroup params={[d, "corruption", "collapse"]}>
-                <LinkShapingNumberSetting params={[d, "corruption", "correlation"]} text="Correlation" placeholder="in %" link_state={this.props.link_state} />
-              </CollapseableInputGroup>
-            </CollapseableInputList>
-            <CollapseableInputList text="Reorder">
-              <LinkShapingNumberSetting params={[d, "reorder", "percentage"]} text="Percentage" placeholder="in %" link_state={this.props.link_state} />
-              <CollapseableInputGroup params={[d, "reorder", "collapse"]}>
-                <LinkShapingNumberSetting params={[d, "reorder", "correlation"]} text="Correlation" placeholder="in %" link_state={this.props.link_state} />
-                <LinkShapingNumberSetting params={[d, "reorder", "gap"]} text="Gap" placeholder="integer" link_state={this.props.link_state}/>
-              </CollapseableInputGroup>
-            </CollapseableInputList>
-          </div>
-        </div>
-      </div>
-    );
-  }
-});
-
-
-var Profile = React.createClass({
-  getInitialState: function() {
-    return {
-      name: "",
-    };
-  },
-
-  handleClick: function() {
-    this.props.link_state("settings").requestChange(
-      new AtcSettings().mergeWithDefaultSettings(this.props.profile.content)
-    );
-  },
-
-  updateName: function(event) {
-    this.setState({name: event.target.value});
-  },
-
-  removeProfile: function() {
-    this.props.link_state("client").value.delete_profile(handleAPI(this.props.link_state, this.props.refreshProfiles), this.props.profile.id);
-  },
-
-  render: function () {
-    return (
-      <div className="list-group-item row">
-        <span className="col-sm-6 text-center vcenter"><kbd>{this.props.profile.name}</kbd></span>
-        <span className="col-sm-2 text-center vcenter">{this.props.profile.content.up.rate} kbps</span>
-        <span className="col-sm-2 text-center vcenter">{this.props.profile.content.down.rate} kbps</span>
-        <button className="col-sm-1 btn btn-info vcenter" onClick={this.handleClick}>Select</button>
-        <button className="col-sm-1 btn btn-danger vcenter" onClick={this.removeProfile}>Delete</button>
-      </div>);
-  }
-});
-
-
-var ProfileList = React.createClass({
-  render: function() {
-    if (this.props.profiles.length == 0) {
-      return false;
-    }
-
-    var profileNodes = this.props.profiles.map(function (profile) {
+    var notifyNodes = this.props.notifications.map(function(item, idx, arr) {
+      var timeout = Math.floor((item.expire_at - new Date().getTime()) / 1000)
+      var cls = "alert alert-" + (NOTIFICATION_TYPES.get(item.type) || item.type);
       return (
-        <Profile refreshProfiles={this.props.refreshProfiles} link_state={this.props.link_state} action='delete' profile={profile} />
-      );
-    }.bind(this));
-
-    return (
-      <div>
-        <h4>Existing Profiles</h4>
-        <p>
-          Select a profile from the list below to use it.
-        </p>
-        <div className="list-group">
-          <div className="list-group-item row">
-            <span className="col-sm-6 text-center vcenter"><b>Name</b></span>
-            <span className="col-sm-2 text-center vcenter"><b>Up Rate</b></span>
-            <span className="col-sm-2 text-center vcenter"><b>Down Rate</b></span>
-            <span className="col-sm-1 text-center vcenter"></span>
-            <span className="col-sm-1 text-center vcenter"></span>
-          </div>
-
-          {profileNodes}
-        </div>
-      </div>
-    );
-  }
-});
-
-
-var CreateProfileWidget = React.createClass({
-  getInitialState: function() {
-    return {
-      name: ""
-    };
-  },
-
-  updateName: function(event) {
-    this.setState({name: event.target.value});
-  },
-
-  newProfile: function() {
-    var settings = this.props.link_state('settings').value;
-    if (settings.down.rate == null &&
-      settings.up.rate == null) {
-      this.props.link_state('errorMsg').requestChange({detail:"Enter your settings below and click Create to save the profile."});
-      return;
-    }
-    if (this.state.name == "") {
-      this.props.link_state('errorMsg').requestChange({detail:"You must give this new profile a name."});
-      return;
-    }
-
-    var addProfile = function() {
-      this.setState({
-        name: "",
-      });
-      this.props.refreshProfiles();
-    }.bind(this);
-
-    var profile = {
-      name: this.state.name,
-      content: settings
-    };
-    console.log("Creating profile " + profile.name);
-    this.props.link_state("client").value.new_profile(handleAPI(this.props.link_state, addProfile), profile);
-  },
-
-  render: function() {
-    return (
-      <div>
-        <h4>New Profile</h4>
-        <p>
-          Enter a name and click "Create" to save a new profile with the settings under "Shaping Settings" below.
-        </p>
-        <input type="text" className="form-control" placeholder="Profile Name" onChange={this.updateName}/>
-        <button className="col-sm-2 btn btn-success" onClick={this.newProfile}>Create</button>
-      </div>
-    );
-  },
-});
-
-
-var ProfilePanel = React.createClass({
-  render: function () {
-    return (
-      <div className="panel-group" id="accordion1" role="tablist" aria-multiselectable="false">
-        <div className="panel panel-default">
-          <div className="panel-heading" data-toggle="collapse" data-parent="#accordion1" href="#collapseProfiles" aria-expanded="false" aria-controls="collapseProfiles">
-            <h3 className="panel-title">
-              Profiles
-            </h3>
-          </div>
-          <div id="collapseProfiles" className="panel-collapse collapse" role="tabpanel">
-            <div className="panel-body">
-              <ProfileList refreshProfiles={this.props.refreshProfiles} link_state={this.props.link_state} profiles={this.props.profiles}/>
-
-              <CreateProfileWidget refreshProfiles={this.props.refreshProfiles} link_state={this.props.link_state}/>
-            </div>
+        <div className={cls} role="alert">
+          <div className="row">
+            <div className="col-md-11">{item.message}</div>
+            <div className="col-md-1">{timeout}</div>
           </div>
         </div>
-      </div>
-    );
-  }
-});
-
-
-var ErrorBox = React.createClass({
-  render: function () {
-    var errors = this.props.error.detail;
-    if (typeof this.props.error.detail === 'string') {
-      errors = Array(this.props.error.detail);
-    } else if (typeof this.props.error.detail === 'object') {
-      errors = this.props.error.detail;
-    }
-    var errorNodes = errors.map(function(error) {
-      return (
-        <li>{error}</li>
       );
     });
+    if (notifyNodes.length == 0) {
+      notifyNodes = (
+        <i>No notifications.</i>
+      );
+    }
     return (
-      <div className="alert alert-danger" role="alert">
-        <ul>
-        {errorNodes}
-        </ul>
-      </div>
-    )
-  }
-});
-
-
-var JSONView = React.createClass({
-  render: function() {
-    return (
-      <div className="col-md-6">
-      <h4>{this.props.label}</h4>
-      <pre>
-        { JSON.stringify(this.props.json, null, 2) }
-      </pre>
-      </div>
-    );
-  }
-});
-
-var ShapingSettings = React.createClass({
-  render: function () {
-    return (
-      <div className="panel-group" id="accordion2" role="tablist" aria-multiselectable="false">
+      <div className="panel-group" id="accordionNotify" role="tablist" aria-multiselectable="false">
         <div className="panel panel-default">
-          <div className="panel-heading" data-toggle="collapse" data-parent="#accordion2" href="#collapseShaping" aria-expanded="false" aria-controls="collapseShaping">
-              <h4 className="panel-title">
-                  Shaping Settings
-              </h4>
+          <div className="panel-heading" data-toggle="collapse" data-parent="#accordionNotify" href="#collapseNotify" aria-expanded="true" aria-controls="collapseNotify">
+            <h3 className="panel-title">
+              Notifications
+            </h3>
           </div>
-          <div id="collapseShaping" className="panel-collapse collapse in" role="tabpanel">
+          <div id="collapseNotify" className="panel-collapse collapse in" role="tabpanel">
             <div className="panel-body">
-              <div className="row">
-                <div className="col-md-6">
-                  <LinkShapingSettings direction="up" link_state={this.props.link_state} />
-                </div>
-                <div className="col-md-6">
-                  <LinkShapingSettings direction="down" link_state={this.props.link_state} />
-                </div>
-              </div>
-
-              <JSONView json={this.props.before} label="Before:" />
-              <JSONView json={this.props.after} label="After:" />
+              {notifyNodes}
             </div>
           </div>
         </div>
@@ -468,251 +64,6 @@ var ShapingSettings = React.createClass({
     );
   }
 });
-
-var TokenFrame = React.createClass({
-  getInitialState: function() {
-    return {
-      token: null,
-      errorMsg: "",
-      interval: null,
-    };
-  },
-
-  componentDidMount: function() {
-    this.getToken();
-    this.interval = setInterval(this.getToken, 3000);
-  },
-
-  componentWillUnmount: function() {
-    if (this.interval != null) {
-      clearInterval(this.interval);
-    }
-  },
-
-  getToken: function() {
-    this.props.client.getToken(function (result) {
-      if (result.status >= 200 && result.status < 300) {
-        this.setState({
-          token: result.json,
-          errorMsg: "",
-        });
-      } else {
-        this.setState({
-          token: null,
-          errorMsg: result.json,
-        });
-      }
-    }.bind(this));
-  },
-
-  getContent: function() {
-    if (this.state.errorMsg != "") {
-      return {
-        token: null,
-        error: this.state.errorMsg,
-      };
-    }
-
-    if (this.state.token == null) {
-      return {
-        token: null,
-        error: null,
-      };
-    }
-
-    var error = null;
-
-    valid_until = new Date(this.state.token.valid_until*1000).toLocaleTimeString();
-    if (this.state.token.valid_until - Math.floor(new Date().getTime() / 1000) < 0) {
-      error = "The time on the ATC server is out of sync.";
-    }
-
-    return {
-      error: {error},
-      token: (
-        <div>
-          <h4>This Machine&#39;s Token: <b>{this.state.token.token}</b></h4>
-          <b>Valid Until:</b> {valid_until}
-          <h4>This Machine&#39; Address: {this.state.token.address}</h4>
-        </div>
-      ),
-    };
-  },
-
-  render: function() {
-    var content = this.getContent();
-    var error_content = null;
-
-    if (content.error != null) {
-      error_content = (
-        <div className="alert alert-danger" role="alert">
-          {content.error}
-        </div>
-      );
-    }
-
-    return (
-      <div className="col-md-6">
-        {error_content}
-        {content.token}
-      </div>
-    );
-  }
-});
-
-var AuthFrame = React.createClass({
-  getInitialState: function() {
-    return {
-      auth: null,
-      token: null,
-      address: null,
-      errorMsg: null,
-    };
-  },
-
-  componentDidMount: function() {
-    this.getAuthInfo();
-  },
-
-  updateToken: function(event) {
-    this.setState({token: event.target.value});
-  },
-
-  updateAddress: function(event) {
-    this.setState({address: event.target.value});
-  },
-
-  getAuthInfo: function() {
-    this.props.client.getAuthInfo(function (result) {
-      if (result.status >= 200 && result.status < 300) {
-        this.setState({
-          auth: result.json,
-          address: result.json.address,
-          errorMsg: "",
-        });
-      } else {
-        this.setState({
-          auth: null,
-          errorMsg: result.json,
-        });
-      }
-    }.bind(this));
-  },
-
-  updateAuth: function() {
-    if (this.state.address == null || this.state.address == "") {
-      // FIXME: report error
-      return;
-    }
-    if (this.state.token == null || this.state.token == "") {
-      // FIXME: report error
-      return;
-    }
-    this.props.client.updateAuthInfo(this.state.address, {token: Number(this.state.token)}, function(result) {
-      if (result.status >= 200 && result.status < 300) {
-        this.setState({
-          // FIXME: success reporting.
-          errorMsg: "",
-        });
-      } else {
-        this.setState({
-          errorMsg: result.json,
-        });
-      }
-    }.bind(this));
-    console.log("Authorizing:", this.state.token, this.state.address);
-  },
-
-  getContent: function() {
-    if (this.state.errorMsg != "") {
-      return {
-        auth: null,
-        error: this.state.errorMsg,
-      };
-    }
-
-    var controlled_ips = null;
-    if (this.state.auth.controlled_ips.length > 0) {
-      controlled_ips = this.state.auth.controlled_ips.map(function (addr) {
-        return (
-          <li><pre><code>{addr}</code></pre></li>
-        );
-      });
-      controlled_ips = (
-        <ul>{controlled_ips}</ul>
-      );
-    } else {
-      controlled_ips = (
-        <i>No Controlled Machines</i>
-      );
-    }
-
-    return {
-      error: null,
-      auth: (
-        <div>
-          <h4>Machines You Can Shape:</h4>
-          {controlled_ips}
-          <p>
-          <b>Note:</b> A machine is always allowed to shape itself.
-          </p>
-
-          <h4>Authorize a New Machine:</h4>
-          <label className="control-label">Address:</label>
-          <input type="text" className="form-control" placeholder="127.0.0.1" onChange={this.updateAddress}/>
-          <label className="control-label">Token:</label>
-          <input type="number" className="form-control" placeholder="12345" onChange={this.updateToken}/>
-          <button className="btn btn-success" onClick={this.updateAuth}>Authorize</button>
-        </div>
-      ),
-    };
-  },
-
-  render: function() {
-    var content = this.getContent();
-    var error_content = null;
-
-    if (content.error != null) {
-      error_content = (
-        <div className="alert alert-danger" role="alert">
-          {content.error}
-        </div>
-      );
-    }
-
-    return (
-      <div className="col-md-6">
-        {error_content}
-        {content.auth}
-      </div>
-    );
-  }
-});
-
-var AuthPanel = React.createClass({
-  render: function() {
-    return (
-      <div className="panel-group" id="accordion3" role="tablist" aria-multiselectable="false">
-        <div className="panel panel-default">
-          <div className="panel-heading" data-toggle="collapse" data-parent="#accordion3" href="#collapseAuth" aria-expanded="false" aria-controls="collapseAuth">
-              <h4 className="panel-title">
-                  Authentication
-              </h4>
-          </div>
-          <div id="collapseAuth" className="panel-collapse collapse in" role="tabpanel">
-            <div className="panel-body">
-
-              <div className="row">
-                <AuthFrame client={this.props.client}/>
-                <TokenFrame client={this.props.client}/>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
-})
 
 
 var Atc = React.createClass({
@@ -723,9 +74,31 @@ var Atc = React.createClass({
       settings: new AtcSettings().getDefaultSettings(),
       current_settings: new AtcSettings().getDefaultSettings(),
       status: atc_status.OFFLINE,
-      errorMsg: "",
       profiles: [],
+      notifications: [],
     };
+  },
+
+  notify: function(type, msg) {
+    this.setState(function(state, props) {
+      return {
+        notifications: state.notifications.concat({
+          expire_at: ERROR_EXPIRY + new Date().getTime(),
+          message: msg,
+          type: type,
+        })
+      };
+    });
+  },
+
+  expireNotifications: function() {
+    this.setState(function(state, props) {
+      return {
+        notifications: state.notifications.filter(function(item, idx, arr) {
+            return item.expire_at >= new Date().getTime();
+        })
+      };
+    })
   },
 
   componentDidMount: function() {
@@ -735,6 +108,13 @@ var Atc = React.createClass({
      */
     this.getCurrentShaping();
     this.getProfiles();
+    this.expiry_interval = setInterval(this.expireNotifications, 1000);
+  },
+
+  componentWillUnmount: function() {
+    if (this.expiry_interval != null) {
+      clearInterval(this.expiry_interval);
+    }
   },
 
   handleClick: function(e) {
@@ -799,13 +179,12 @@ var Atc = React.createClass({
     this.state.client.get_profiles(function (result) {
       if (result.status >= 200 && result.status < 300) {
         this.setState({
-          errorMsg: '',
           profiles: result.json,
         });
       } else {
+        this.error(result.json.detail);
         this.setState({
           profiles: [],
-          errorMsg: result.json,
         });
       }
     }.bind(this));
@@ -816,21 +195,19 @@ var Atc = React.createClass({
       if (result.status == 404) {
         this.setState({
           status: atc_status.INACTIVE,
-          errorMsg: '',
           settings: new AtcSettings().getDefaultSettings(),
           current_settings: new AtcSettings().getDefaultSettings(),
         });
       } else if (result.status >= 200 && result.status < 300) {
         this.setState({
           status: atc_status.ACTIVE,
-          errorMsg: '',
           settings: result.json,
           current_settings: this.state.settings,
         });
       } else {
+        this.error(result.json.detail);
         this.setState({
           status: atc_status.OFFLINE,
-          errorMsg: result.json,
           settings: new AtcSettings().getDefaultSettings(),
         });
       }
@@ -847,9 +224,9 @@ var Atc = React.createClass({
           current_settings: new AtcSettings().getDefaultSettings(),
         });
       } else if (result.status >= 500) {
+        this.notify("error", result.json.detail);
         this.setState({
           status: atc_status.OFFLINE,
-          errorMsg: result.json,
         });
       }
     }.bind(this));
@@ -862,24 +239,19 @@ var Atc = React.createClass({
       if (result.status >= 200 && result.status < 300) {
         this.setState({
           status: atc_status.ACTIVE,
-          errorMsg: '',
           settings: result.json,
           current_settings: {down: this.state.settings.down, up: this.state.settings.up},
         });
       } else if (result.status == 400) {
-        var errors = Array();
         for (var key in result.json) {
-          errors = errors.concat(result.data[key].map(function(msg) {
-            return key + ': ' + msg;
-          }));
+          result.data[key].map(function(msg) {
+            this.notify("error", key + ': ' + msg);
+          }.bind(this));
         }
-        this.setState({
-          errorMsg: errors,
-        });
       } else if (result.status >= 500) {
+        this.notify("error", result.json.detail);
         this.setState({
           status: atc_status.OFFLINE,
-          errorMsg: result.json,
         });
       }
 
@@ -890,9 +262,6 @@ var Atc = React.createClass({
     link_state = this.linkState;
     var err_msg = "";
     var update_button = false;
-    if (this.state.errorMsg != "") {
-      err_msg = <ErrorBox error={this.state.errorMsg} />
-    }
     if (this.hasChanged()) {
       update_button = <ShapingButton id="update_button" status={atc_status.OUTDATED} onClick={this.updateClick} />
     }
@@ -906,9 +275,10 @@ var Atc = React.createClass({
           </div>
         </div>
 
-        <AuthPanel client={this.state.client} />
-        <ProfilePanel refreshProfiles={this.getProfiles} link_state={link_state} profiles={this.state.profiles} />
-        <ShapingSettings link_state={link_state} before={this.state.settings} after={this.state.current_settings} />
+        <NotificationPanel notifications={this.state.notifications} />
+        <AuthPanel client={this.state.client} notify={this.notify}/>
+        <ProfilePanel refreshProfiles={this.getProfiles} link_state={link_state} profiles={this.state.profiles} notify={this.notify} />
+        <ShapingSettings link_state={link_state} before={this.state.settings} after={this.state.current_settings} notify={this.notify} />
       </div>
     )
   }

--- a/atc/django-atc-demo-ui/atc_demo_ui/static/js/atc.js
+++ b/atc/django-atc-demo-ui/atc_demo_ui/static/js/atc.js
@@ -18,639 +18,898 @@
  * or a list of keys
  */
 var RecursiveLinkStateMixin = {
-    linkState: function (path) {
-        function setPath (obj, path, value) {
-            var leaf = resolvePath(obj, path);
-            leaf.obj[leaf.key] = value;
-        }
-
-        function getPath (obj, path) {
-            var leaf = resolvePath(obj, path);
-            return leaf.obj[leaf.key];
-        }
-
-        function resolvePath (obj, keys) {
-            if (typeof keys === 'string') {
-                keys = keys.split('_');
-            }
-            var lastIndex = keys.length - 1;
-            var current = obj;
-            for (var i = 0; i < lastIndex; i++) {
-                var key = keys[i];
-                current = current[key];
-            }
-            return {
-                obj: current,
-                key: keys[lastIndex]
-            };
-        }
-
-        return {
-            value: getPath(this.state, path),
-            requestChange: function(newValue) {
-                setPath(this.state, path, newValue);
-                this.forceUpdate();
-            }.bind(this)
-        };
+  linkState: function (path) {
+    function setPath (obj, path, value) {
+      var leaf = resolvePath(obj, path);
+      leaf.obj[leaf.key] = value;
     }
+
+    function getPath (obj, path) {
+      var leaf = resolvePath(obj, path);
+      return leaf.obj[leaf.key];
+    }
+
+    function resolvePath (obj, keys) {
+      if (typeof keys === 'string') {
+        keys = keys.split('_');
+      }
+      var lastIndex = keys.length - 1;
+      var current = obj;
+      for (var i = 0; i < lastIndex; i++) {
+        var key = keys[i];
+        current = current[key];
+      }
+      return {
+        obj: current,
+        key: keys[lastIndex]
+      };
+    }
+
+    return {
+      value: getPath(this.state, path),
+      requestChange: function(newValue) {
+        setPath(this.state, path, newValue);
+        this.forceUpdate();
+      }.bind(this)
+    };
+  }
 };
 
 var IdentifyableObject = {
-    getIdentifier: function () {
-        return this.props.params.join('_');
-    },
+  getIdentifier: function () {
+    return this.props.params.join('_');
+  },
 };
 
 var atc_status = {
-    OFFLINE: 0,
-    ACTIVE: 1,
-    INACTIVE: 2,
-    OUTDATED: 3,
+  OFFLINE: 0,
+  ACTIVE: 1,
+  INACTIVE: 2,
+  OUTDATED: 3,
 };
 
 
 function handleAPI(link_state, callback) {
-    return function(rc) {
-        /* 2XX error codes are OK */
-        if (rc.status < 300 && rc.status >= 200) {
-            if (callback !== undefined) {
-                callback(rc);
-            }    
-        } else {
-            err = false;
-            t = typeof rc.json;
-            if (t === 'undefined') {
-                err = {
-                    detail: "Could not complete request due to server error.",
-                }
-            } else if (t === 'string') {
-                s = rc.json
-
-                /* trim off the first line */
-                s = s.trim().substring(s.length, s.indexOf('\n'))
-
-                /* take the second line as the error message */
-                s = s.trim().substring(0, s.indexOf('\n'))
-
-                err = {
-                    detail: s,
-                };
-            } else if (t === 'object') {
-                err = rc.json;
-            }
-
-            if (err) {
-                link_state('errorMsg').requestChange(err);
-            } else {
-                console.log("Not sure what to do with error value " + t + " '" + rc.json + "'");
-            }
+  return function(rc) {
+    /* 2XX error codes are OK */
+    if (rc.status < 300 && rc.status >= 200) {
+      if (callback !== undefined) {
+        callback(rc);
+      }  
+    } else {
+      err = false;
+      t = typeof rc.json;
+      if (t === 'undefined') {
+        err = {
+          detail: "Could not complete request due to server error.",
         }
+      } else if (t === 'string') {
+        s = rc.json
+
+        /* trim off the first line */
+        s = s.trim().substring(s.length, s.indexOf('\n'))
+
+        /* take the second line as the error message */
+        s = s.trim().substring(0, s.indexOf('\n'))
+
+        err = {
+          detail: s,
+        };
+      } else if (t === 'object') {
+        err = rc.json;
+      }
+
+      if (err) {
+        link_state('errorMsg').requestChange(err);
+      } else {
+        console.log("Not sure what to do with error value " + t + " '" + rc.json + "'");
+      }
     }
+  }
 }
 
+function capitalizeFirstLetter(s) {
+    return s.charAt(0).toUpperCase() + s.slice(1);
+}
 
 var ShapingButton = React.createClass({
-    render: function () {
-        button_values = [
-            {
-                message: "ATC is not running",
-                css: "danger",
-            },
-            {
-                message: "Turn Off",
-                css: "success",
-            },
-            {
-                message: "Turn On",
-                css: "default",
-            },
-            {
-                message: "Update Shaping",
-                css: "warning",
-            },
-        ];
+  render: function () {
+    button_values = [
+      {
+        message: "ATC is not running",
+        css: "warning",
+      },
+      {
+        message: "Turn Off",
+        css: "danger",
+      },
+      {
+        message: "Turn On",
+        css: "primary",
+      },
+      {
+        message: "Update Shaping",
+        css: "success",
+      },
+    ];
 
-        content = button_values[this.props.status];
-        return (
-            <button type="button" id={this.props.id} className={"btn btn-" + content.css} disabled={this.props.status == atc_status.OFFLINE} onClick={this.props.onClick}>
-                {content.message}
-            </button>
-        );
-    }
+    content = button_values[this.props.status];
+    return (
+      <button type="button" id={this.props.id} className={"btn btn-" + content.css} disabled={this.props.status == atc_status.OFFLINE} onClick={this.props.onClick}>
+        {content.message}
+      </button>
+    );
+  }
 });
 
 
 var LinkShapingNumberSetting = React.createClass({
-    mixins: [IdentifyableObject],
-    render: function () {
-        id = this.getIdentifier();
-        link_state = this.props.link_state("settings_" + id);
-        return (
-            <div className="form-group">
-                <label htmlFor={id} className="col-sm-3 control-label">{this.props.text}</label>
-                <div className="col-sm-9">
-                    <input type="number" defaultValue={link_state.value} className="form-control" id={id} placeholder={this.props.placeholder} min="0" max={this.props.max_value} valueLink={link_state} />
-                </div>
-            </div>
-        )
-    }
+  mixins: [IdentifyableObject],
+  render: function () {
+    id = this.getIdentifier();
+    link_state = this.props.link_state("settings_" + id);
+    return (
+      <div className="form-group">
+        <label htmlFor={id} className="col-sm-3 control-label">{this.props.text}</label>
+        <div className="col-sm-9">
+          <input type="number" defaultValue={link_state.value} className="form-control" id={id} placeholder={this.props.placeholder} min="0" max={this.props.max_value} valueLink={link_state} />
+        </div>
+      </div>
+    )
+  }
 });
 
 
 var LinkShapingPercentSetting = React.createClass({
-    render: function () {
-        return (
-            <LinkShapingNumberSetting input_id={this.props.input_id} text={this.props.text} placeholder="In %" link_state={this.props.link_state} max_value="100" />
-        )
-    }
+  render: function () {
+    return (
+      <LinkShapingNumberSetting input_id={this.props.input_id} text={this.props.text} placeholder="In %" link_state={this.props.link_state} max_value="100" />
+    )
+  }
 });
 
 
 var CollapseableInputList = React.createClass({
-    render: function () {
-        return (
-            <fieldset className="accordion-group">
-                <legend>{this.props.text}</legend>
-                {this.props.children}
-            </fieldset>
-        );
-    }
+  render: function () {
+    return (
+      <fieldset className="accordion-group">
+        <legend>{this.props.text}</legend>
+        {this.props.children}
+      </fieldset>
+    );
+  }
 });
 
 
 var CollapseableInputGroup = React.createClass({
-    mixins: [IdentifyableObject],
-    getInitialState: function () {
-        return {collapsed: true};
-    },
+  mixins: [IdentifyableObject],
+  getInitialState: function () {
+    return {collapsed: true};
+  },
 
-    handleClick: function (e) {
-        this.setState({collapsed: !this.state.collapsed})
-    },
+  handleClick: function (e) {
+    this.setState({collapsed: !this.state.collapsed})
+  },
 
-    render: function () {
-        id = this.getIdentifier();
-        var text = this.state.collapsed ? 'Show more' : 'Show less';
-        return (
-            <div>
-                <div className="accordion-heading">
-                    <a className="accordion-toggle" data-toggle="collapse" data-target={"#" + id} href="#" onClick={this.handleClick}>{text}</a>
-                </div>
-                <div className="accordion-body collapse" id={id}>
-                    <div className="accordion-inner">
-                        {this.props.children}
-                    </div>
-                </div>
-            </div>
-        );
-    }
+  render: function () {
+    id = this.getIdentifier();
+    var text = this.state.collapsed ? 'Show more' : 'Show less';
+    return (
+      <div>
+        <div className="accordion-heading">
+          <a className="accordion-toggle" data-toggle="collapse" data-target={"#" + id} href="#" onClick={this.handleClick}>{text}</a>
+        </div>
+        <div className="accordion-body collapse" id={id}>
+          <div className="accordion-inner">
+            {this.props.children}
+          </div>
+        </div>
+      </div>
+    );
+  }
 });
 
 
 var LinkShapingSettings = React.createClass({
-    render: function () {
-        d = this.props.direction;
-        return (
-            <div className="well" id={d + "_well"}>
-                <h3>{d + "link"}</h3>
-                <div className="form-horizontal accordion">
-                    <LinkShapingNumberSetting params={[d, "rate"]} text="Bandwidth" placeholder="in kbps" link_state={this.props.link_state} />
-                    <CollapseableInputList text="Latency">
-                        <LinkShapingNumberSetting params={[d, "delay", "delay"]} text="Delay" placeholder="in ms" link_state={this.props.link_state} />
-                        <CollapseableInputGroup params={[d, "delay", "collapse"]}>
-                            <LinkShapingNumberSetting params={[d, "delay","jitter"]} text="Jitter" placeholder="in %" link_state={this.props.link_state} />
-                            <LinkShapingNumberSetting params={[d, "delay", "correlation"]} text="Correlation" placeholder="in %" link_state={this.props.link_state} />
-                        </CollapseableInputGroup>
-                    </CollapseableInputList>
-                    <CollapseableInputList text="Loss">
-                        <LinkShapingNumberSetting params={[d, "loss", "percentage"]} text="Percentage" placeholder="in %" link_state={this.props.link_state} />
-                        <CollapseableInputGroup params={[d, "loss", "collapse"]}>
-                            <LinkShapingNumberSetting params={[d, "loss", "correlation"]} text="Correlation" placeholder="in %" link_state={this.props.link_state} />
-                        </CollapseableInputGroup>
-                    </CollapseableInputList>
-                    <CollapseableInputList text="Corruption">
-                        <LinkShapingNumberSetting params={[d, "corruption", "percentage"]} text="Percentage" placeholder="in %" link_state={this.props.link_state} />
-                        <CollapseableInputGroup params={[d, "corruption", "collapse"]}>
-                            <LinkShapingNumberSetting params={[d, "corruption", "correlation"]} text="Correlation" placeholder="in %" link_state={this.props.link_state} />
-                        </CollapseableInputGroup>
-                    </CollapseableInputList>
-                    <CollapseableInputList text="Reorder">
-                        <LinkShapingNumberSetting params={[d, "reorder", "percentage"]} text="Percentage" placeholder="in %" link_state={this.props.link_state} />
-                        <CollapseableInputGroup params={[d, "reorder", "collapse"]}>
-                            <LinkShapingNumberSetting params={[d, "reorder", "correlation"]} text="Correlation" placeholder="in %" link_state={this.props.link_state} />
-                            <LinkShapingNumberSetting params={[d, "reorder", "gap"]} text="Gap" placeholder="integer" link_state={this.props.link_state}/>
-                        </CollapseableInputGroup>
-                    </CollapseableInputList>
-                </div>
-            </div>
-        );
-    }
-});
-
-
-var ShapingSettings = React.createClass({
-    render: function () {
-        return (
-            <div>
-                <div className="col-md-6">
-                    <LinkShapingSettings direction="up" link_state={this.props.link_state} />
-                </div>
-                <div className="col-md-6">
-                    <LinkShapingSettings direction="down" link_state={this.props.link_state} />
-                </div>
-            </div>
-        );
-    }
+  render: function () {
+    d = this.props.direction;
+    return (
+      <div>
+        <h4>{capitalizeFirstLetter(d) + "link"}:</h4>
+        <div className="well" id={d + "_well"}>
+          <div className="form-horizontal accordion">
+            <CollapseableInputList text="Bandwidth">
+              <LinkShapingNumberSetting params={[d, "rate"]} text="Rate" placeholder="in kbps" link_state={this.props.link_state} />
+            </CollapseableInputList>
+            <CollapseableInputList text="Latency">
+              <LinkShapingNumberSetting params={[d, "delay", "delay"]} text="Delay" placeholder="in ms" link_state={this.props.link_state} />
+              <CollapseableInputGroup params={[d, "delay", "collapse"]}>
+                <LinkShapingNumberSetting params={[d, "delay","jitter"]} text="Jitter" placeholder="in %" link_state={this.props.link_state} />
+                <LinkShapingNumberSetting params={[d, "delay", "correlation"]} text="Correlation" placeholder="in %" link_state={this.props.link_state} />
+              </CollapseableInputGroup>
+            </CollapseableInputList>
+            <CollapseableInputList text="Loss">
+              <LinkShapingNumberSetting params={[d, "loss", "percentage"]} text="Percentage" placeholder="in %" link_state={this.props.link_state} />
+              <CollapseableInputGroup params={[d, "loss", "collapse"]}>
+                <LinkShapingNumberSetting params={[d, "loss", "correlation"]} text="Correlation" placeholder="in %" link_state={this.props.link_state} />
+              </CollapseableInputGroup>
+            </CollapseableInputList>
+            <CollapseableInputList text="Corruption">
+              <LinkShapingNumberSetting params={[d, "corruption", "percentage"]} text="Percentage" placeholder="in %" link_state={this.props.link_state} />
+              <CollapseableInputGroup params={[d, "corruption", "collapse"]}>
+                <LinkShapingNumberSetting params={[d, "corruption", "correlation"]} text="Correlation" placeholder="in %" link_state={this.props.link_state} />
+              </CollapseableInputGroup>
+            </CollapseableInputList>
+            <CollapseableInputList text="Reorder">
+              <LinkShapingNumberSetting params={[d, "reorder", "percentage"]} text="Percentage" placeholder="in %" link_state={this.props.link_state} />
+              <CollapseableInputGroup params={[d, "reorder", "collapse"]}>
+                <LinkShapingNumberSetting params={[d, "reorder", "correlation"]} text="Correlation" placeholder="in %" link_state={this.props.link_state} />
+                <LinkShapingNumberSetting params={[d, "reorder", "gap"]} text="Gap" placeholder="integer" link_state={this.props.link_state}/>
+              </CollapseableInputGroup>
+            </CollapseableInputList>
+          </div>
+        </div>
+      </div>
+    );
+  }
 });
 
 
 var Profile = React.createClass({
-    getInitialState: function() {
-        return {
-            name: "",
-        };
-    },
+  getInitialState: function() {
+    return {
+      name: "",
+    };
+  },
 
-    handleClick: function() {
-        this.props.link_state("settings").requestChange(
-            new AtcSettings().mergeWithDefaultSettings(this.props.profile.content)
-        );
-    },
+  handleClick: function() {
+    this.props.link_state("settings").requestChange(
+      new AtcSettings().mergeWithDefaultSettings(this.props.profile.content)
+    );
+  },
 
-    updateName: function(event) {
-        this.setState({name: event.target.value});
-    },
+  updateName: function(event) {
+    this.setState({name: event.target.value});
+  },
 
-    removeProfile: function() {
-        this.props.link_state("client").value.delete_profile(handleAPI(this.props.link_state, this.props.refreshProfiles), this.props.profile.id);
-    },
+  removeProfile: function() {
+    this.props.link_state("client").value.delete_profile(handleAPI(this.props.link_state, this.props.refreshProfiles), this.props.profile.id);
+  },
 
-    render: function () {
-        return (
-            <div className="list-group-item row">
-                <span className="col-sm-6 text-center vcenter"><kbd>{this.props.profile.name}</kbd></span>
-                <span className="col-sm-2 text-center vcenter">{this.props.profile.content.up.rate} kbps</span>
-                <span className="col-sm-2 text-center vcenter">{this.props.profile.content.down.rate} kbps</span>
-                <button className="col-sm-1 btn btn-info vcenter" onClick={this.handleClick}>Select</button>
-                <button className="col-sm-1 btn btn-danger vcenter" onClick={this.removeProfile}>Delete</button>
-            </div>);
-    }
+  render: function () {
+    return (
+      <div className="list-group-item row">
+        <span className="col-sm-6 text-center vcenter"><kbd>{this.props.profile.name}</kbd></span>
+        <span className="col-sm-2 text-center vcenter">{this.props.profile.content.up.rate} kbps</span>
+        <span className="col-sm-2 text-center vcenter">{this.props.profile.content.down.rate} kbps</span>
+        <button className="col-sm-1 btn btn-info vcenter" onClick={this.handleClick}>Select</button>
+        <button className="col-sm-1 btn btn-danger vcenter" onClick={this.removeProfile}>Delete</button>
+      </div>);
+  }
 });
 
 
 var ProfileList = React.createClass({
-    render: function() {
-        if (this.props.profiles.length == 0) {
-            return false;
-        }
-
-        var profileNodes = this.props.profiles.map(function (profile) {
-            return (
-                <Profile refreshProfiles={this.props.refreshProfiles} link_state={this.props.link_state} action='delete' profile={profile} />
-            );
-        }.bind(this));
-
-        return (
-            <div>
-                <h3>Existing Profiles</h3>
-                <p>
-                    Select a profile from the list below to use it.
-                </p>
-                <div className="list-group">
-                    <div className="list-group-item row">
-                        <span className="col-sm-6 text-center vcenter"><b>Name</b></span>
-                        <span className="col-sm-2 text-center vcenter"><b>Up Rate</b></span>
-                        <span className="col-sm-2 text-center vcenter"><b>Down Rate</b></span>
-                        <span className="col-sm-1 text-center vcenter"></span>
-                        <span className="col-sm-1 text-center vcenter"></span>
-                    </div>
-
-                    {profileNodes}
-                </div>
-            </div>
-        );
+  render: function() {
+    if (this.props.profiles.length == 0) {
+      return false;
     }
+
+    var profileNodes = this.props.profiles.map(function (profile) {
+      return (
+        <Profile refreshProfiles={this.props.refreshProfiles} link_state={this.props.link_state} action='delete' profile={profile} />
+      );
+    }.bind(this));
+
+    return (
+      <div>
+        <h4>Existing Profiles</h4>
+        <p>
+          Select a profile from the list below to use it.
+        </p>
+        <div className="list-group">
+          <div className="list-group-item row">
+            <span className="col-sm-6 text-center vcenter"><b>Name</b></span>
+            <span className="col-sm-2 text-center vcenter"><b>Up Rate</b></span>
+            <span className="col-sm-2 text-center vcenter"><b>Down Rate</b></span>
+            <span className="col-sm-1 text-center vcenter"></span>
+            <span className="col-sm-1 text-center vcenter"></span>
+          </div>
+
+          {profileNodes}
+        </div>
+      </div>
+    );
+  }
 });
 
 
 var CreateProfileWidget = React.createClass({
-    getInitialState: function() {
-        return {
-            name: ""
-        };
-    },
+  getInitialState: function() {
+    return {
+      name: ""
+    };
+  },
 
-    updateName: function(event) {
-        this.setState({name: event.target.value});
-    },
+  updateName: function(event) {
+    this.setState({name: event.target.value});
+  },
 
-    newProfile: function() {
-        var settings = this.props.link_state('settings').value;
-        if (settings.down.rate == null &&
-            settings.up.rate == null) {
-            this.props.link_state('errorMsg').requestChange({detail:"Enter your settings below and click Create to save the profile."});
-            return;
-        }
-        if (this.state.name == "") {
-            this.props.link_state('errorMsg').requestChange({detail:"You must give this new profile a name."});
-            return;
-        }
+  newProfile: function() {
+    var settings = this.props.link_state('settings').value;
+    if (settings.down.rate == null &&
+      settings.up.rate == null) {
+      this.props.link_state('errorMsg').requestChange({detail:"Enter your settings below and click Create to save the profile."});
+      return;
+    }
+    if (this.state.name == "") {
+      this.props.link_state('errorMsg').requestChange({detail:"You must give this new profile a name."});
+      return;
+    }
 
-        var addProfile = function() {
-            this.setState({
-                name: "",
-            });
-            this.props.refreshProfiles();
-        }.bind(this);
+    var addProfile = function() {
+      this.setState({
+        name: "",
+      });
+      this.props.refreshProfiles();
+    }.bind(this);
 
-        var profile = {
-            name: this.state.name,
-            content: settings
-        };
-        console.log("Creating profile " + profile.name);
-        this.props.link_state("client").value.new_profile(handleAPI(this.props.link_state, addProfile), profile);
-    },
+    var profile = {
+      name: this.state.name,
+      content: settings
+    };
+    console.log("Creating profile " + profile.name);
+    this.props.link_state("client").value.new_profile(handleAPI(this.props.link_state, addProfile), profile);
+  },
 
-    render: function() {
-        return (
-            <div>
-                <h3>New Profile</h3>
-                <p>
-                    Enter a name and click "Create" to save a new profile.
-                </p>
-                <input type="text" className="form-control" placeholder="Profile Name" onChange={this.updateName}/>
-                <button className="col-sm-2 btn btn-success" onClick={this.newProfile}>Create</button>
-            </div>
-        );
-    },
+  render: function() {
+    return (
+      <div>
+        <h4>New Profile</h4>
+        <p>
+          Enter a name and click "Create" to save a new profile with the settings under "Shaping Settings" below.
+        </p>
+        <input type="text" className="form-control" placeholder="Profile Name" onChange={this.updateName}/>
+        <button className="col-sm-2 btn btn-success" onClick={this.newProfile}>Create</button>
+      </div>
+    );
+  },
 });
 
 
 var ProfilePanel = React.createClass({
-    render: function () {
-        return (
-            <div className="panel panel-default">
-                <div className="panel-body">
-                    <ProfileList refreshProfiles={this.props.refreshProfiles} link_state={this.props.link_state} profiles={this.props.profiles}/>
+  render: function () {
+    return (
+      <div className="panel-group" id="accordion1" role="tablist" aria-multiselectable="false">
+        <div className="panel panel-default">
+          <div className="panel-heading" data-toggle="collapse" data-parent="#accordion1" href="#collapseProfiles" aria-expanded="false" aria-controls="collapseProfiles">
+            <h3 className="panel-title">
+              Profiles
+            </h3>
+          </div>
+          <div id="collapseProfiles" className="panel-collapse collapse" role="tabpanel">
+            <div className="panel-body">
+              <ProfileList refreshProfiles={this.props.refreshProfiles} link_state={this.props.link_state} profiles={this.props.profiles}/>
 
-                    <CreateProfileWidget refreshProfiles={this.props.refreshProfiles} link_state={this.props.link_state}/>
-                </div>
+              <CreateProfileWidget refreshProfiles={this.props.refreshProfiles} link_state={this.props.link_state}/>
             </div>
-        );
-    }
+          </div>
+        </div>
+      </div>
+    );
+  }
 });
 
 
 var ErrorBox = React.createClass({
-    render: function () {
-        var errors = this.props.error.detail;
-        if (typeof this.props.error.detail === 'string') {
-            errors = Array(this.props.error.detail);
-        } else if (typeof this.props.error.detail === 'object') {
-            errors = this.props.error.detail;
-        }
-        var errorNodes = errors.map(function(error) {
-            return (
-                <li>{error}</li>
-            );
-        });
-        return (
-            <div className="alert alert-danger" role="alert">
-                <ul>
-                {errorNodes}
-                </ul>
-            </div>
-        )
+  render: function () {
+    var errors = this.props.error.detail;
+    if (typeof this.props.error.detail === 'string') {
+      errors = Array(this.props.error.detail);
+    } else if (typeof this.props.error.detail === 'object') {
+      errors = this.props.error.detail;
     }
+    var errorNodes = errors.map(function(error) {
+      return (
+        <li>{error}</li>
+      );
+    });
+    return (
+      <div className="alert alert-danger" role="alert">
+        <ul>
+        {errorNodes}
+        </ul>
+      </div>
+    )
+  }
 });
 
 
 var JSONView = React.createClass({
-    render: function() {
-        return (
-            <div className="col-md-6">
-            <h3>{this.props.label}</h3>
-            <pre>
-                { JSON.stringify(this.props.json, null, 2) }
-            </pre>
-            </div>
-        );
-    }
+  render: function() {
+    return (
+      <div className="col-md-6">
+      <h4>{this.props.label}</h4>
+      <pre>
+        { JSON.stringify(this.props.json, null, 2) }
+      </pre>
+      </div>
+    );
+  }
 });
 
+var ShapingSettings = React.createClass({
+  render: function () {
+    return (
+      <div className="panel-group" id="accordion2" role="tablist" aria-multiselectable="false">
+        <div className="panel panel-default">
+          <div className="panel-heading" data-toggle="collapse" data-parent="#accordion2" href="#collapseShaping" aria-expanded="false" aria-controls="collapseShaping">
+              <h4 className="panel-title">
+                  Shaping Settings
+              </h4>
+          </div>
+          <div id="collapseShaping" className="panel-collapse collapse in" role="tabpanel">
+            <div className="panel-body">
+              <div className="row">
+                <div className="col-md-6">
+                  <LinkShapingSettings direction="up" link_state={this.props.link_state} />
+                </div>
+                <div className="col-md-6">
+                  <LinkShapingSettings direction="down" link_state={this.props.link_state} />
+                </div>
+              </div>
 
-var JSONDiff = React.createClass({
-    render: function() {
-        return (
-            <div className="row">
-                <JSONView json={this.props.before} label="Before:" />
-                <JSONView json={this.props.after} label="After:" />
+              <JSONView json={this.props.before} label="Before:" />
+              <JSONView json={this.props.after} label="After:" />
             </div>
-        );
-    }
+          </div>
+        </div>
+      </div>
+    );
+  }
 });
+
+var TokenFrame = React.createClass({
+  getInitialState: function() {
+    return {
+      token: null,
+      errorMsg: "",
+      interval: null,
+    };
+  },
+
+  componentDidMount: function() {
+    this.getToken();
+    this.interval = setInterval(this.getToken, 3000);
+  },
+
+  componentWillUnmount: function() {
+    if (this.interval != null) {
+      clearInterval(this.interval);
+    }
+  },
+
+  getToken: function() {
+    this.props.client.getToken(function (result) {
+      if (result.status >= 200 && result.status < 300) {
+        this.setState({
+          token: result.json,
+          errorMsg: "",
+        });
+      } else {
+        this.setState({
+          token: null,
+          errorMsg: result.json,
+        });
+      }
+    }.bind(this));
+  },
+
+  getContent: function() {
+    if (this.state.errorMsg != "") {
+      return {
+        token: null,
+        error: this.state.errorMsg,
+      };
+    }
+
+    if (this.state.token == null) {
+      return {
+        token: null,
+        error: null,
+      };
+    }
+
+    var error = null;
+
+    valid_until = new Date(this.state.token.valid_until*1000).toLocaleTimeString();
+    if (this.state.token.valid_until - Math.floor(new Date().getTime() / 1000) < 0) {
+      error = "The time on the ATC server is out of sync.";
+    }
+
+    return {
+      error: {error},
+      token: (
+        <div>
+          <h4>This Machine&#39;s Token: <b>{this.state.token.token}</b></h4>
+          <b>Valid Until:</b> {valid_until}
+          <h4>This Machine&#39; Address: {this.state.token.address}</h4>
+        </div>
+      ),
+    };
+  },
+
+  render: function() {
+    var content = this.getContent();
+    var error_content = null;
+
+    if (content.error != null) {
+      error_content = (
+        <div className="alert alert-danger" role="alert">
+          {content.error}
+        </div>
+      );
+    }
+
+    return (
+      <div className="col-md-6">
+        {error_content}
+        {content.token}
+      </div>
+    );
+  }
+});
+
+var AuthFrame = React.createClass({
+  getInitialState: function() {
+    return {
+      auth: null,
+      token: null,
+      address: null,
+      errorMsg: null,
+    };
+  },
+
+  componentDidMount: function() {
+    this.getAuthInfo();
+  },
+
+  updateToken: function(event) {
+    this.setState({token: event.target.value});
+  },
+
+  updateAddress: function(event) {
+    this.setState({address: event.target.value});
+  },
+
+  getAuthInfo: function() {
+    this.props.client.getAuthInfo(function (result) {
+      if (result.status >= 200 && result.status < 300) {
+        this.setState({
+          auth: result.json,
+          address: result.json.address,
+          errorMsg: "",
+        });
+      } else {
+        this.setState({
+          auth: null,
+          errorMsg: result.json,
+        });
+      }
+    }.bind(this));
+  },
+
+  updateAuth: function() {
+    if (this.state.address == null || this.state.address == "") {
+      // FIXME: report error
+      return;
+    }
+    if (this.state.token == null || this.state.token == "") {
+      // FIXME: report error
+      return;
+    }
+    this.props.client.updateAuthInfo(this.state.address, {token: Number(this.state.token)}, function(result) {
+      if (result.status >= 200 && result.status < 300) {
+        this.setState({
+          // FIXME: success reporting.
+          errorMsg: "",
+        });
+      } else {
+        this.setState({
+          errorMsg: result.json,
+        });
+      }
+    }.bind(this));
+    console.log("Authorizing:", this.state.token, this.state.address);
+  },
+
+  getContent: function() {
+    if (this.state.errorMsg != "") {
+      return {
+        auth: null,
+        error: this.state.errorMsg,
+      };
+    }
+
+    var controlled_ips = null;
+    if (this.state.auth.controlled_ips.length > 0) {
+      controlled_ips = this.state.auth.controlled_ips.map(function (addr) {
+        return (
+          <li><pre><code>{addr}</code></pre></li>
+        );
+      });
+      controlled_ips = (
+        <ul>{controlled_ips}</ul>
+      );
+    } else {
+      controlled_ips = (
+        <i>No Controlled Machines</i>
+      );
+    }
+
+    return {
+      error: null,
+      auth: (
+        <div>
+          <h4>Machines You Can Shape:</h4>
+          {controlled_ips}
+          <p>
+          <b>Note:</b> A machine is always allowed to shape itself.
+          </p>
+
+          <h4>Authorize a New Machine:</h4>
+          <label className="control-label">Address:</label>
+          <input type="text" className="form-control" placeholder="127.0.0.1" onChange={this.updateAddress}/>
+          <label className="control-label">Token:</label>
+          <input type="number" className="form-control" placeholder="12345" onChange={this.updateToken}/>
+          <button className="btn btn-success" onClick={this.updateAuth}>Authorize</button>
+        </div>
+      ),
+    };
+  },
+
+  render: function() {
+    var content = this.getContent();
+    var error_content = null;
+
+    if (content.error != null) {
+      error_content = (
+        <div className="alert alert-danger" role="alert">
+          {content.error}
+        </div>
+      );
+    }
+
+    return (
+      <div className="col-md-6">
+        {error_content}
+        {content.auth}
+      </div>
+    );
+  }
+});
+
+var AuthPanel = React.createClass({
+  render: function() {
+    return (
+      <div className="panel-group" id="accordion3" role="tablist" aria-multiselectable="false">
+        <div className="panel panel-default">
+          <div className="panel-heading" data-toggle="collapse" data-parent="#accordion3" href="#collapseAuth" aria-expanded="false" aria-controls="collapseAuth">
+              <h4 className="panel-title">
+                  Authentication
+              </h4>
+          </div>
+          <div id="collapseAuth" className="panel-collapse collapse in" role="tabpanel">
+            <div className="panel-body">
+
+              <div className="row">
+                <AuthFrame client={this.props.client}/>
+                <TokenFrame client={this.props.client}/>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+})
 
 
 var Atc = React.createClass({
-    mixins: [RecursiveLinkStateMixin],
-    getInitialState: function() {
-        return {
-            client: new AtcRestClient(this.props.endpoint),
-            settings: new AtcSettings().getDefaultSettings(),
-            current_settings: new AtcSettings().getDefaultSettings(),
-            status: atc_status.OFFLINE,
-            errorMsg: "",
-            profiles: [],
-        };
-    },
+  mixins: [RecursiveLinkStateMixin],
+  getInitialState: function() {
+    return {
+      client: new AtcRestClient(this.props.endpoint),
+      settings: new AtcSettings().getDefaultSettings(),
+      current_settings: new AtcSettings().getDefaultSettings(),
+      status: atc_status.OFFLINE,
+      errorMsg: "",
+      profiles: [],
+    };
+  },
 
-    componentDidMount: function() {
-        this.getCurrentShaping();
-        /** FIXME we are calling getCurrentShaping to make sure that
-         * current_settings === settings.... let's be smarter than that.
-         */
-        this.getCurrentShaping();
-        this.getProfiles();
-    },
+  componentDidMount: function() {
+    this.getCurrentShaping();
+    /** FIXME we are calling getCurrentShaping to make sure that
+     * current_settings === settings.... let's be smarter than that.
+     */
+    this.getCurrentShaping();
+    this.getProfiles();
+  },
 
-    handleClick: function(e) {
-        if (e.type == "click") {
-            if (this.state.status == atc_status.ACTIVE) {
-                this.unsetShaping();
-            } else if (this.state.status == atc_status.INACTIVE) {
-                this.setShaping();
-            }
-        }
-    },
-
-    updateClick: function(e) {
-        if (e.type == "click") {
-            this.setShaping();
-        }
-    },
-
-    hasChanged: function() {
-        /* TODO: improve object comparaison e.g null == "", 1 == "1"*/
-        function objectEquals(x, y) {
-            if (typeof(x) === 'number') {
-                x = x.toString();
-            }
-            if (typeof(y) === 'number') {
-                y = y.toString();
-            }
-            if (typeof(x) != typeof(y)) {
-                return false;
-            }
-
-            if (Array.isArray(x) || Array.isArray(y)) {
-                return x.toString() === y.toString();
-            }
-
-            if (x === null && y === null) {
-                return true;
-            }
-
-            if (typeof(x) === 'object' && x !== null) {
-                x_keys = Object.keys(x);
-                y_keys = Object.keys(y);
-                if (x_keys.sort().toString() !== y_keys.sort().toString()) {
-                    console.error('Object do not have the same keys: ' +
-                        x_keys.sort().toString() + ' vs ' +
-                        y_keys.sort().toString()
-                    );
-                    return false;
-                }
-                equals = true;
-                for (key of x_keys) {
-                    equals &= objectEquals(x[key], y[key]);
-                }
-                return equals;
-            }
-            return x.toString() === y.toString();
-        }
-        return !objectEquals(this.state.settings, this.state.current_settings);
-    },
-
-    getProfiles: function() {
-        this.state.client.get_profiles(function (result) {
-            if (result.status >= 200 && result.status < 300) {
-                this.setState({
-                    errorMsg: '',
-                    profiles: result.json,
-                });
-            } else {
-                this.setState({
-                    profiles: [],
-                    errorMsg: result.json,
-                });
-            }
-        }.bind(this));
-    },
-
-    getCurrentShaping: function() {
-        console.log('getCurrentShaping');
-        this.state.client.getCurrentShaping(function (result) {
-            if (result.status == 404) {
-                this.setState({
-                    status: atc_status.INACTIVE,
-                    errorMsg: '',
-                    settings: new AtcSettings().getDefaultSettings(),
-                    current_settings: new AtcSettings().getDefaultSettings(),
-                });
-            } else if (result.status >= 200 && result.status < 300) {
-                this.setState({
-                    status: atc_status.ACTIVE,
-                    errorMsg: '',
-                    settings: result.json,
-                    current_settings: this.state.settings,
-                });
-            } else {
-                this.setState({
-                    status: atc_status.OFFLINE,
-                    errorMsg: result.json,
-                    settings: new AtcSettings().getDefaultSettings(),
-                });
-            }
-        }.bind(this));
-    },
-
-    unsetShaping: function() {
-        console.log('unsetShaping');
-        this.state.client.unshape(function (result) {
-            if (result.status >= 200 && result.status < 300) {
-                this.setState({
-                    status: atc_status.INACTIVE,
-                    settings: new AtcSettings().getDefaultSettings(),
-                    current_settings: new AtcSettings().getDefaultSettings(),
-                });
-            } else if (result.status >= 500) {
-                this.setState({
-                    status: atc_status.OFFLINE,
-                    errorMsg: result.json,
-                });
-            }
-        }.bind(this));
-    },
-
-
-    setShaping: function() {
-        console.log('setShaping');
-        this.state.client.shape(function (result) {
-            if (result.status >= 200 && result.status < 300) {
-                this.setState({
-                    status: atc_status.ACTIVE,
-                    errorMsg: '',
-                    settings: result.json,
-                    current_settings: {down: this.state.settings.down, up: this.state.settings.up},
-                });
-            } else if (result.status == 400) {
-                var errors = Array();
-                for (var key in result.json) {
-                    errors = errors.concat(result.data[key].map(function(msg) {
-                        return key + ': ' + msg;
-                    }));
-                }
-                this.setState({
-                    errorMsg: errors,
-                });
-            } else if (result.status >= 500) {
-                this.setState({
-                    status: atc_status.OFFLINE,
-                    errorMsg: result.json,
-                });
-            }
-
-        }.bind(this), {down: this.state.settings.down, up: this.state.settings.up});
-    },
-
-    render: function () {
-        link_state = this.linkState;
-        var err_msg = "";
-        var update_button = false;
-        if (this.state.errorMsg != "") {
-            err_msg = <ErrorBox error={this.state.errorMsg} />
-        }
-        if (this.hasChanged()) {
-            update_button = <ShapingButton id="update_button" status={atc_status.OUTDATED} onClick={this.updateClick} />
-        }
-        return (
-            <div>
-            <div className="row">
-                <div id="shaping_buttons" className="col-md-12 text-center">
-                    {update_button}
-                    <ShapingButton id="shaping_button" status={this.state.status} onClick={this.handleClick} />
-                    {err_msg}
-                </div>
-            </div>
-            <div className="row">
-                <ProfilePanel refreshProfiles={this.getProfiles} link_state={link_state} profiles={this.state.profiles} />
-            </div>
-
-            <div className="row">
-                <ShapingSettings link_state={link_state} />
-            </div>
-            <JSONDiff before={this.state.settings} after={this.state.current_settings} />
-            </div>
-        )
+  handleClick: function(e) {
+    if (e.type == "click") {
+      if (this.state.status == atc_status.ACTIVE) {
+        this.unsetShaping();
+      } else if (this.state.status == atc_status.INACTIVE) {
+        this.setShaping();
+      }
     }
+  },
+
+  updateClick: function(e) {
+    if (e.type == "click") {
+      this.setShaping();
+    }
+  },
+
+  hasChanged: function() {
+    /* TODO: improve object comparaison e.g null == "", 1 == "1"*/
+    function objectEquals(x, y) {
+      if (typeof(x) === 'number') {
+        x = x.toString();
+      }
+      if (typeof(y) === 'number') {
+        y = y.toString();
+      }
+      if (typeof(x) != typeof(y)) {
+        return false;
+      }
+
+      if (Array.isArray(x) || Array.isArray(y)) {
+        return x.toString() === y.toString();
+      }
+
+      if (x === null && y === null) {
+        return true;
+      }
+
+      if (typeof(x) === 'object' && x !== null) {
+        x_keys = Object.keys(x);
+        y_keys = Object.keys(y);
+        if (x_keys.sort().toString() !== y_keys.sort().toString()) {
+          console.error('Object do not have the same keys: ' +
+            x_keys.sort().toString() + ' vs ' +
+            y_keys.sort().toString()
+          );
+          return false;
+        }
+        equals = true;
+        for (key of x_keys) {
+          equals &= objectEquals(x[key], y[key]);
+        }
+        return equals;
+      }
+      return x.toString() === y.toString();
+    }
+    return !objectEquals(this.state.settings, this.state.current_settings);
+  },
+
+  getProfiles: function() {
+    this.state.client.get_profiles(function (result) {
+      if (result.status >= 200 && result.status < 300) {
+        this.setState({
+          errorMsg: '',
+          profiles: result.json,
+        });
+      } else {
+        this.setState({
+          profiles: [],
+          errorMsg: result.json,
+        });
+      }
+    }.bind(this));
+  },
+
+  getCurrentShaping: function() {
+    this.state.client.getCurrentShaping(function (result) {
+      if (result.status == 404) {
+        this.setState({
+          status: atc_status.INACTIVE,
+          errorMsg: '',
+          settings: new AtcSettings().getDefaultSettings(),
+          current_settings: new AtcSettings().getDefaultSettings(),
+        });
+      } else if (result.status >= 200 && result.status < 300) {
+        this.setState({
+          status: atc_status.ACTIVE,
+          errorMsg: '',
+          settings: result.json,
+          current_settings: this.state.settings,
+        });
+      } else {
+        this.setState({
+          status: atc_status.OFFLINE,
+          errorMsg: result.json,
+          settings: new AtcSettings().getDefaultSettings(),
+        });
+      }
+    }.bind(this));
+  },
+
+  unsetShaping: function() {
+    console.log('unsetShaping');
+    this.state.client.unshape(function (result) {
+      if (result.status >= 200 && result.status < 300) {
+        this.setState({
+          status: atc_status.INACTIVE,
+          settings: new AtcSettings().getDefaultSettings(),
+          current_settings: new AtcSettings().getDefaultSettings(),
+        });
+      } else if (result.status >= 500) {
+        this.setState({
+          status: atc_status.OFFLINE,
+          errorMsg: result.json,
+        });
+      }
+    }.bind(this));
+  },
+
+
+  setShaping: function() {
+    console.log('setShaping');
+    this.state.client.shape(function (result) {
+      if (result.status >= 200 && result.status < 300) {
+        this.setState({
+          status: atc_status.ACTIVE,
+          errorMsg: '',
+          settings: result.json,
+          current_settings: {down: this.state.settings.down, up: this.state.settings.up},
+        });
+      } else if (result.status == 400) {
+        var errors = Array();
+        for (var key in result.json) {
+          errors = errors.concat(result.data[key].map(function(msg) {
+            return key + ': ' + msg;
+          }));
+        }
+        this.setState({
+          errorMsg: errors,
+        });
+      } else if (result.status >= 500) {
+        this.setState({
+          status: atc_status.OFFLINE,
+          errorMsg: result.json,
+        });
+      }
+
+    }.bind(this), {down: this.state.settings.down, up: this.state.settings.up});
+  },
+
+  render: function () {
+    link_state = this.linkState;
+    var err_msg = "";
+    var update_button = false;
+    if (this.state.errorMsg != "") {
+      err_msg = <ErrorBox error={this.state.errorMsg} />
+    }
+    if (this.hasChanged()) {
+      update_button = <ShapingButton id="update_button" status={atc_status.OUTDATED} onClick={this.updateClick} />
+    }
+    return (
+      <div>
+        <div className="row">
+          <div id="shaping_buttons" className="col-md-12 text-center">
+            {update_button}
+            <ShapingButton id="shaping_button" status={this.state.status} onClick={this.handleClick} />
+            {err_msg}
+          </div>
+        </div>
+
+        <AuthPanel client={this.state.client} />
+        <ProfilePanel refreshProfiles={this.getProfiles} link_state={link_state} profiles={this.state.profiles} />
+        <ShapingSettings link_state={link_state} before={this.state.settings} after={this.state.current_settings} />
+      </div>
+    )
+  }
 });

--- a/atc/django-atc-demo-ui/atc_demo_ui/templates/atc_demo_ui/base.html
+++ b/atc/django-atc-demo-ui/atc_demo_ui/templates/atc_demo_ui/base.html
@@ -14,6 +14,10 @@
     <script src="{% static 'vendor/react/JSXTransformer-0.13.3.js' %}"></script>
     <script type="text/jsx" src="{% static 'js/atc-api.js' %}"></script>
     <script type="text/jsx" src="{% static 'js/atc-profile-storage.js' %}"></script>
+    <script type="text/jsx" src="{% static 'js/atc-utils.js' %}"></script>
+    <script type="text/jsx" src="{% static 'js/atc-auth.js' %}"></script>
+    <script type="text/jsx" src="{% static 'js/atc-profiles.js' %}"></script>
+    <script type="text/jsx" src="{% static 'js/atc-shaping.js' %}"></script>
     <script type="text/jsx" src="{% static 'js/atc.js' %}"></script>
     <link rel="stylesheet" href="{% static 'css/atc.css' %}" />
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->


### PR DESCRIPTION
I refactored a lot of the UI javascript code and added some new functionality:

- Moved all the UI elements into panes, except for the buttons at the top of the page.
- Added a notification pane which includes error messages, info messages, and warnings for 10 seconds before dismissing them (timer shows up on the right and counts down).
- Refactored most of the error handling/display code to use the new notification pane instead. 
- Panes are now collapsible. Auth and Profiles default to closed while Settings and Notifications default to open.
- Added an Authentication pane which includes information about shapable devices on the left, and the machine's token on the right. Fixes #116 and #117

Screenshot of added panes:
![Sample of New Panes](http://i.imgur.com/VZn83tF.png)

