### PR TITLE
Remove rate policing from tc filter.

### DIFF
--- a/atc/atcd/atcd/backends/linux.py
+++ b/atc/atcd/atcd/backends/linux.py
@@ -317,9 +317,7 @@ class AtcdLinuxShaper(AtcdThriftHandlerTask):
                         protocol=ETH_P_IP,
                         prio=PRIO,
                         classid=idx,
-                        rate="{}kbit".format(shaping.rate or 2**22 - 1),
-                        burst=self.burst_size,
-                        action='drop')
+                        )
         except NetlinkError as e:
             return TrafficControlRc(
                 code=ReturnCode.NETLINK_FW_ERROR,


### PR DESCRIPTION
Currently ATC rate limits both in the htb qdisc and in the filter. I've seen unreliable results,
especially when tested with something like speedtest. Often the throughput remains too low, 
or it is very bursty. Removing rate-limiting from the filter and keeping it only in htb seems to make 
things better.