### PR TITLE
Fix react on older browsers

### DIFF
--- a/atc/django-atc-demo-ui/atc_demo_ui/static/js/atc.js
+++ b/atc/django-atc-demo-ui/atc_demo_ui/static/js/atc.js
@@ -19,19 +19,19 @@ var atc_status = {
 };
 
 
-var NOTIFICATION_TYPES = new Map([
-  ["error", "danger"],
-  ["info", "info"],
-  ["warn", "warning"],
-  ["success", "success"],
-]);
+var NOTIFICATION_TYPES = {
+  "error": "danger",
+  "info": "info",
+  "warn": "warning",
+  "success": "success",
+};
 
 
 var NotificationPanel = React.createClass({
   render: function () {
     var notifyNodes = this.props.notifications.map(function(item, idx, arr) {
       var timeout = Math.floor((item.expire_at - new Date().getTime()) / 1000)
-      var cls = "alert alert-" + (NOTIFICATION_TYPES.get(item.type) || item.type);
+      var cls = "alert alert-" + (NOTIFICATION_TYPES[item.type] || item.type);
       return (
         <div className={cls} role="alert">
           <div className="row">

--- a/atc/django-atc-demo-ui/atc_demo_ui/static/js/atc.js
+++ b/atc/django-atc-demo-ui/atc_demo_ui/static/js/atc.js
@@ -165,9 +165,9 @@ var Atc = React.createClass({
           return false;
         }
         equals = true;
-        for (key of x_keys) {
-          equals &= objectEquals(x[key], y[key]);
-        }
+        x_keys.forEach(function (key, index) {
+            equals &= objectEquals(x[key], y[key]);
+        });
         return equals;
       }
       return x.toString() === y.toString();

--- a/atc/django-atc-demo-ui/atc_demo_ui/templates/atc_demo_ui/base.html
+++ b/atc/django-atc-demo-ui/atc_demo_ui/templates/atc_demo_ui/base.html
@@ -10,6 +10,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- React.js -->
+    <script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/2.2.0/es5-shim.min.js"></script>
     <script src="{% static 'vendor/react/react-0.13.3.js' %}"></script>
     <script src="{% static 'vendor/react/JSXTransformer-0.13.3.js' %}"></script>
     <script type="text/jsx" src="{% static 'js/atc-api.js' %}"></script>

--- a/atc/django-atc-demo-ui/atc_demo_ui/templates/atc_demo_ui/base.html
+++ b/atc/django-atc-demo-ui/atc_demo_ui/templates/atc_demo_ui/base.html
@@ -11,6 +11,7 @@
 
     <!-- React.js -->
     <script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/2.2.0/es5-shim.min.js"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/es5-shim/2.2.0/es5-sham.min.js"></script>
     <script src="{% static 'vendor/react/react-0.13.3.js' %}"></script>
     <script src="{% static 'vendor/react/JSXTransformer-0.13.3.js' %}"></script>
     <script type="text/jsx" src="{% static 'js/atc-api.js' %}"></script>


### PR DESCRIPTION
- replace `for ... of` by `Array.prototype.forEach` : es6 only:
  https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of
- add es5shim js library:
  http://facebook.github.io/react/docs/working-with-the-browser.html#browser-support-and-polyfills