### PR TITLE
Command line argument to buffer packets instead of dropping

### DIFF
--- a/atc/atcd/atcd/AtcdThriftHandlerTask.py
+++ b/atc/atcd/atcd/AtcdThriftHandlerTask.py
@@ -164,6 +164,13 @@ class AtcdThriftHandlerTask(ThriftHandlerTask):
         help='Amount of bytes that can be burst at a capped speed '
                 '[%(default)s]'
     )
+    dont_drop_packets = option(
+        action='store_true',
+        help='[EXPERIMENTAL] Do not drop packets when going above max allowed'
+             ' rate. Packets will be queued instead. Please mind that this'
+             ' option will likely disappear in the future and is only provided'
+             '  as a workaround until better longer term solution is found.',
+    )
     fresh_start = option(
         action='store_true',
         help='Bypass saved shapings from a previous run [%(default)s]',

--- a/atc/atcd/atcd/backends/linux.py
+++ b/atc/atcd/atcd/backends/linux.py
@@ -312,14 +312,20 @@ class AtcdLinuxShaper(AtcdThriftHandlerTask):
             )
         )
         try:
+            extra_args = {}
+            if not self.dont_drop_packets:
+                extra_args.update({
+                    'rate': "{}kbit".format(shaping.rate or 2**22 - 1),
+                    'burst': self.burst_size,
+                    'action': 'drop',
+                })
             self.ipr.tc(RTM_NEWTFILTER, 'fw', ifid, mark,
                         parent=parent,
                         protocol=ETH_P_IP,
                         prio=PRIO,
                         classid=idx,
-                        rate="{}kbit".format(shaping.rate or 2**22 - 1),
-                        burst=self.burst_size,
-                        action='drop')
+                        **extra_args
+                        )
         except NetlinkError as e:
             return TrafficControlRc(
                 code=ReturnCode.NETLINK_FW_ERROR,


### PR DESCRIPTION
atcd --atcd-dont-drop-packets

This is provided as a workaround for a bunch of issues that were
reported by users where they would prefer packets to be buffered (and
hence providing the expected throughput)  rather than being dropped
causing the network to collapse.

Fixes #86
Fixes #103
Fixes #123
Fixes #125
and most likely #135