### PR TITLE
[docker] Bump docker image to use atc 0.1.2

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -28,6 +28,7 @@ There is currently 2 environment variables:
 * ATCD_LAN (default *eth1*)
 * ATCD_MODE (default *secure*)
 * ATCD_BURST_SIZE (default *12000*)
+* ATCD_OPTIONS (default *empty*) free form options to pass to atcd
 
 To run atcd with the default settings:
 

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -1,6 +1,7 @@
 sed -i -e "s/{{ATCD_WAN}}/${ATCD_WAN}/
     s/{{ATCD_LAN}}/${ATCD_LAN}/
     s/{{ATCD_MODE}}/${ATCD_MODE}/
+    s/{{ATCD_OPTIONS}}/${ATCD_OPTIONS}/
     s/{{ATCD_BURST_SIZE}}/${ATCD_BURST_SIZE}/" ./supervisord.conf
 
 # start all the services

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -21,7 +21,7 @@ supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 serverurl=unix:///tmp/supervisor.sock ; use a unix:// URL  for a unix socket
 
 [program:atcd]
-command=/usr/local/bin/atcd --atcd-wan {{ATCD_WAN}} --atcd-lan {{ATCD_LAN}} --atcd-burst-size {{ATCD_BURST_SIZE}} --atcd-mode {{ATCD_MODE}}
+command=/usr/local/bin/atcd --atcd-wan {{ATCD_WAN}} --atcd-lan {{ATCD_LAN}} --atcd-burst-size {{ATCD_BURST_SIZE}} --atcd-mode {{ATCD_MODE}} {{ATCD_OPTIONS}}
 stdout_events_enabled=true
 stderr_events_enabled=true
 


### PR DESCRIPTION
Also add ATCD_OPTIONS environment flag to allow passing free form
options on top of the basic setting ones (e.g network interface, secure
mode...)_