### PR TITLE
Fix chef on centos6

### DIFF
--- a/chef/atc/recipes/atcui.rb
+++ b/chef/atc/recipes/atcui.rb
@@ -87,6 +87,7 @@ else
 end
 
 service 'atcui' do
+  provider Chef::Provider::Service::Upstart
   supports :restart => true
   action [:enable, :start]
 end


### PR DESCRIPTION
Fixed chef on centos6 by explicitly specifying the upstart service provider.

Chef was defaulting to the older redhat init system, which was incorrect since centos6 supports upstart.

This is okay since we only support the upstart init system. (See the big case in the lines above the svc definition).

If we decide to support systemd, or another init system, this will need to change.