### PR TITLE
Fixed bug that made all tokens identical

### DIFF
--- a/src/daemon/atcd.go
+++ b/src/daemon/atcd.go
@@ -264,9 +264,8 @@ func (atcd *Atcd) token(group *DbGroup) string {
 
 func (atcd *Atcd) otp(group *DbGroup) *otp.TOTP {
 	return &otp.TOTP{
-		Secret:         fmt.Sprintf("%s::%d", group.secret, group.id),
-		Period:         atcd.options.OtpTimeout,
-		IsBase32Secret: true,
+		Secret: fmt.Sprintf("%s::%d", group.secret, group.id),
+		Period: atcd.options.OtpTimeout,
 	}
 }
 


### PR DESCRIPTION
Removed the `IsBase32Secret` param when we create tokens.

This was causing tokens to be identical for different shaping groups.
