### PR TITLE
atc_api requires bind information now.

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	API_URL_MAP = map[string]HandlerFunc{
-		"/":                 RedirectHandler(ServerData.ApiUrl + "shape"),
+		"/":                 RedirectHandler(ROOT_URL + "/shape"),
 		"/info":             InfoHandler,
 		"/group":            GroupsHandler,
 		"/group/{id}":       GroupHandler,

--- a/src/api/api_test.go
+++ b/src/api/api_test.go
@@ -229,7 +229,7 @@ type testServer struct {
 }
 
 func newTestServer(t *testing.T) testServer {
-	srv, err := ListenAndServe(net.JoinHostPort(ServerAddr, "0"), "", "", "sqlite3", ":memory:")
+	srv, err := ListenAndServe(net.JoinHostPort(ServerAddr, "0"), "", "", "sqlite3", ":memory:", "0.0.0.0", "::")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,12 +249,8 @@ func (s testServer) Cleanup() {
 }
 
 func (s testServer) client(addr string) testClient {
-	if addr == "" {
-		addr = s.GetAddr()
-	} else {
-		_, port, _ := net.SplitHostPort(s.GetAddr())
-		addr = net.JoinHostPort(addr, port)
-	}
+	_, port, _ := net.SplitHostPort(s.GetAddr())
+	addr = net.JoinHostPort(addr, port)
 	return testClient{addr, s.t}
 }
 

--- a/src/atc_api/main.go
+++ b/src/atc_api/main.go
@@ -22,6 +22,7 @@ func TestAtcdConnection(addr, proto string) error {
 func main() {
 	args := ParseArgs()
 
+	// Make sure connection to the daemon is working.
 	err := TestAtcdConnection(args.ThriftAddr, args.ThriftProtocol)
 	if err != nil {
 		api.Log.Println("failed to connect to atcd server:", err)
@@ -32,9 +33,13 @@ func main() {
 		api.Log.Println("Connected to atcd socket on", args.ThriftAddr)
 	}
 
+	if args.IPv4 == "" || args.IPv6 == "" {
+		api.Log.Fatalln("You must provide either -4 or -6 arguments to run the API.")
+	}
+
 	api.Log.Println("Listening on", args.BindAddr)
 
-	srv, err := api.ListenAndServe(args.BindAddr, args.ThriftAddr, args.ThriftProtocol, args.DbDriver, args.DbConnstr)
+	srv, err := api.ListenAndServe(args.BindAddr, args.ThriftAddr, args.ThriftProtocol, args.DbDriver, args.DbConnstr, args.IPv4, args.IPv6)
 	if err != nil {
 		api.Log.Fatalln("failed to listen and serve:", err)
 	}
@@ -52,6 +57,8 @@ type Arguments struct {
 	DbDriver       string
 	DbConnstr      string
 	WarnOnly       bool
+	IPv4           string
+	IPv6           string
 }
 
 func ParseArgs() Arguments {
@@ -61,6 +68,8 @@ func ParseArgs() Arguments {
 	db_driver := flag.String("D", "sqlite3", "database driver")
 	db_connstr := flag.String("Q", "atc_api.db", "database driver connection parameters")
 	warn_only := flag.Bool("W", false, "only warn if the thrift server isn't reachable")
+	ipv4 := flag.String("4", "", "IPv4 address for the API")
+	ipv6 := flag.String("6", "", "IPv6 address for the API")
 	flag.Parse()
 
 	return Arguments{
@@ -70,5 +79,7 @@ func ParseArgs() Arguments {
 		DbDriver:       *db_driver,
 		DbConnstr:      *db_connstr,
 		WarnOnly:       *warn_only,
+		IPv4:           *ipv4,
+		IPv6:           *ipv6,
 	}
 }


### PR DESCRIPTION
When running the `atc_api` process, you now specify the `-4` and `-6` options, which
tell the API which addresses it should expose to the client.
The javascript client uses this information to enable shaping on both IPv4 and IPv6
interfaces.

Better documentation for this workflow forthcoming.
