### PR TITLE
Group Creation responds with token

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	API_URL_MAP = map[string]HandlerFunc{
-		"/":                 RedirectHandler(ServerData.ApiUrl + "shape"),
+		"/":                 RedirectHandler(ROOT_URL + "/shape"),
 		"/info":             InfoHandler,
 		"/group":            GroupsHandler,
 		"/group/{id}":       GroupHandler,

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -58,7 +58,11 @@ func GroupsHandler(w http.ResponseWriter, r *http.Request) (interface{}, HttpErr
 		if err != nil {
 			return nil, HttpErrorf(http.StatusBadGateway, "Could not create group: %v", err)
 		}
-		return grp, nil
+		token, err := atcd.GetGroupToken(grp.ID)
+		if err != nil {
+			return nil, HttpErrorf(http.StatusBadGateway, "Could not get group token: %v", err)
+		}
+		return CreatedGroup{grp, token}, nil
 	case "GET":
 		addr := GetClientAddr(r)
 		group, err := atcd.GetGroupWith(addr)

--- a/src/api/api_test.go
+++ b/src/api/api_test.go
@@ -229,7 +229,7 @@ type testServer struct {
 }
 
 func newTestServer(t *testing.T) testServer {
-	srv, err := ListenAndServe(net.JoinHostPort(ServerAddr, "0"), "", "", "sqlite3", ":memory:")
+	srv, err := ListenAndServe(net.JoinHostPort(ServerAddr, "0"), "", "", "sqlite3", ":memory:", "0.0.0.0", "::")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,12 +249,8 @@ func (s testServer) Cleanup() {
 }
 
 func (s testServer) client(addr string) testClient {
-	if addr == "" {
-		addr = s.GetAddr()
-	} else {
-		_, port, _ := net.SplitHostPort(s.GetAddr())
-		addr = net.JoinHostPort(addr, port)
-	}
+	_, port, _ := net.SplitHostPort(s.GetAddr())
+	addr = net.JoinHostPort(addr, port)
 	return testClient{addr, s.t}
 }
 

--- a/src/api/types.go
+++ b/src/api/types.go
@@ -19,6 +19,12 @@ type DaemonInfo struct {
 	Version  string `json:"version"`
 }
 
+// used by group creation response
+type CreatedGroup struct {
+	*atc_thrift.ShapingGroup
+	Token string `json:"token"`
+}
+
 type GroupToken struct {
 	Token string `json:"token"`
 	Id    int64  `json:"id"`

--- a/src/atc_api/main.go
+++ b/src/atc_api/main.go
@@ -22,6 +22,7 @@ func TestAtcdConnection(addr, proto string) error {
 func main() {
 	args := ParseArgs()
 
+	// Make sure connection to the daemon is working.
 	err := TestAtcdConnection(args.ThriftAddr, args.ThriftProtocol)
 	if err != nil {
 		api.Log.Println("failed to connect to atcd server:", err)
@@ -32,9 +33,13 @@ func main() {
 		api.Log.Println("Connected to atcd socket on", args.ThriftAddr)
 	}
 
+	if args.IPv4 == "" || args.IPv6 == "" {
+		api.Log.Fatalln("You must provide either -4 or -6 arguments to run the API.")
+	}
+
 	api.Log.Println("Listening on", args.BindAddr)
 
-	srv, err := api.ListenAndServe(args.BindAddr, args.ThriftAddr, args.ThriftProtocol, args.DbDriver, args.DbConnstr)
+	srv, err := api.ListenAndServe(args.BindAddr, args.ThriftAddr, args.ThriftProtocol, args.DbDriver, args.DbConnstr, args.IPv4, args.IPv6)
 	if err != nil {
 		api.Log.Fatalln("failed to listen and serve:", err)
 	}
@@ -52,6 +57,8 @@ type Arguments struct {
 	DbDriver       string
 	DbConnstr      string
 	WarnOnly       bool
+	IPv4           string
+	IPv6           string
 }
 
 func ParseArgs() Arguments {
@@ -61,6 +68,8 @@ func ParseArgs() Arguments {
 	db_driver := flag.String("D", "sqlite3", "database driver")
 	db_connstr := flag.String("Q", "atc_api.db", "database driver connection parameters")
 	warn_only := flag.Bool("W", false, "only warn if the thrift server isn't reachable")
+	ipv4 := flag.String("4", "", "IPv4 address for the API")
+	ipv6 := flag.String("6", "", "IPv6 address for the API")
 	flag.Parse()
 
 	return Arguments{
@@ -70,5 +79,7 @@ func ParseArgs() Arguments {
 		DbDriver:       *db_driver,
 		DbConnstr:      *db_connstr,
 		WarnOnly:       *warn_only,
+		IPv4:           *ipv4,
+		IPv6:           *ipv6,
 	}
 }


### PR DESCRIPTION
Requests to create a group to the API should respond with a valid token for the group.

This is going to be used by the UI later to implement dual-stack shaping.

Merge #174 before this one.
