### PR TITLE
Dual-stack AJAX UI calls

### DIFF
--- a/static/index.htm
+++ b/static/index.htm
@@ -55,7 +55,7 @@ of patent rights can be found in the PATENTS file in the same directory.
         <div id="atc_demo_ui" />
         <script type="text/jsx">
           React.render(
-            <Atc endpoint={{.ApiUrl}}/>,
+            <Atc {{with .Primary}}primary={{.}}{{end}} {{with .Secondary}}secondary={{.}}{{end}} endpoint={{.ApiUrl}} />,
             document.getElementById('atc_demo_ui')
           );
         </script>

--- a/static/js/atc.js
+++ b/static/js/atc.js
@@ -51,7 +51,7 @@ var NotificationPanel = React.createClass({
 var Atc = React.createClass({
   getInitialState: function() {
     return {
-      client: new AtcRestClient(this.props.endpoint),
+      client: new AtcRestClient(this.props.primary, this.props.secondary, this.props.endpoint),
       profiles: null,
       potential: null,
       current: null,


### PR DESCRIPTION
The UI needs to be able to make dual-stack AJAX calls. To do this, we pass the bind information from #174 to the UI and modify the api.js file so that it supports dual-stacked calls where necessary.

Currently on the group join call is going to be dual-stacked, although we may need more later.

Merge #175  before this one.
