### PR TITLE
Added ipv6 to test setup

### DIFF
--- a/utils/test-cleanup.sh
+++ b/utils/test-cleanup.sh
@@ -5,8 +5,6 @@ if [ "$(whoami)" != "root" ] ; then
     exit 0
 fi
 
-echo 0 > /proc/sys/net/ipv4/ip_forward
-
 # Remove outside interfaces
 ip link del dev cli1
 ip link del dev lan1

--- a/utils/test-setup.sh
+++ b/utils/test-setup.sh
@@ -5,8 +5,6 @@ if [ "$(whoami)" != "root" ] ; then
     exit 0
 fi
 
-echo 1 > /proc/sys/net/ipv4/ip_forward
-
 # Create the network namespaces
 ip netns add cli
 ip netns add atc
@@ -62,12 +60,29 @@ ip link set dev lan1 master br0
 ip link set dev wan1 master br1
 ip link set dev srv1 master br1
 
-# assign IP addresses to inside interfaces
-ip netns exec cli ip addr add dev cli0 192.168.3.2/24 broadcast 192.168.3.255
-ip netns exec atc ip addr add dev lan0 192.168.3.1/24 broadcast 192.168.3.255
-ip netns exec atc ip addr add dev wan0 192.168.4.1/24 broadcast 192.168.4.255
-ip netns exec srv ip addr add dev srv0 192.168.4.2/24 broadcast 192.168.4.255
+# Enable ip forwarding for both IPv6 and IPv4.
+ip netns exec atc sysctl -w net.ipv4.ip_forward=1
+ip netns exec atc sysctl -w net.ipv6.conf.all.forwarding=1
 
-# Add default routes so that out-of-network IPs will be forwarded.
-ip netns exec cli ip route add default via 192.168.3.1 dev cli0
-ip netns exec srv ip route add default via 192.168.4.1 dev srv0
+# IPv4 Client network: 192.168.3.0/24
+# IPv4 Server network: 192.168.4.0/24
+# IPv6 Client network: fc00:1::0/32
+# IPv6 Server network: fc00:2::0/32
+
+# assign IPv4 addresses to inside interfaces
+ip netns exec cli ip -4 addr add dev cli0 192.168.3.2/24 broadcast 192.168.3.255
+ip netns exec atc ip -4 addr add dev lan0 192.168.3.1/24 broadcast 192.168.3.255
+ip netns exec atc ip -4 addr add dev wan0 192.168.4.1/24 broadcast 192.168.4.255
+ip netns exec srv ip -4 addr add dev srv0 192.168.4.2/24 broadcast 192.168.4.255
+
+# assign IPv6 addresses to inside interfaces
+ip netns exec cli ip -6 addr add dev cli0 fc00:1::2/32
+ip netns exec atc ip -6 addr add dev lan0 fc00:1::1/32
+ip netns exec atc ip -6 addr add dev wan0 fc00:2::1/32
+ip netns exec srv ip -6 addr add dev srv0 fc00:2::2/32
+
+# Add routes so that out-of-network IPs will be forwarded.
+ip netns exec cli ip -4 route add 192.168.4.0/24 via 192.168.3.1 dev cli0
+ip netns exec srv ip -4 route add 192.168.3.0/24 via 192.168.4.1 dev srv0
+ip netns exec cli ip -6 route add fc00:2::0/32 via fc00:1::1 dev cli0
+ip netns exec srv ip -6 route add fc00:1::0/32 via fc00:2::1 dev srv0


### PR DESCRIPTION
Enable ipv6 packet forwarding and add ipv6 addresses and routes to the test network namespaces.
