### PR TITLE
Handle errors from server

### DIFF
--- a/src/atcd/main.go
+++ b/src/atcd/main.go
@@ -58,7 +58,9 @@ func main() {
 
 	// Create and run the thrift service.
 	atcd := daemon.NewAtcd(db, shaper, options)
-	runServer(atcd, args.ThriftAddr)
+	if err := runServer(atcd, args.ThriftAddr); err != nil {
+		daemon.Log.Fatalln("Server failed:", err)
+	}
 }
 
 type Args struct {


### PR DESCRIPTION
Prior to this PR `atcd` used to bail silently if the thrift server fails to start for some reason. Now we catch and log the error.