### PR TITLE
[travis] create travis spec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+# sudo is required in order to be able to run src/shaping tests
+sudo: required
+# trusty is required to support setting up dummy interfaces with netlink
+dist: trusty
+language: go
+go:
+    - 1.5
+# Enforce upstream path
+go_import_path: github.com/facebook/augmented-traffic-control
+install:
+    # install dependencies
+    - ./setup.sh
+    # install assets
+    - make src/api/bindata.go
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Augmented Traffic Control
 
 [![GoDoc](https://godoc.org/github.com/facebook/augmented-traffic-control?status.svg)](https://godoc.org/github.com/facebook/augmented-traffic-control)
+[![Build Status](https://travis-ci.org/facebook/augmented-traffic-control.svg?branch=master)](https://travis-ci.org/facebook/augmented-traffic-control)
 
 ## WARNING
 

--- a/setup.sh
+++ b/setup.sh
@@ -2,8 +2,6 @@
 
 PROJECT=github.com/facebook/augmented-traffic-control
 SRC="$PROJECT/src"
-GOPATH="$(pwd)/.gopath/"
-export GOPATH
 
 make_gopath() {
     echo "Setting up GOPATH in $GOPATH"
@@ -26,8 +24,12 @@ get_depends() {
 depends() {
     # Special since it's a build-time dependency and isn't imported by any code
     echo "github.com/jteeuwen/go-bindata/go-bindata"
-    go list -f '{{range .Imports}}{{.}}{{"\n"}}{{end}}' "$SRC/daemon" "$SRC/atcd" "$SRC/api" "$SRC/atc_api" | sort -u | fgrep . | grep -v "augmented-traffic-control"
+    go list -f '{{range .Imports}}{{.}}{{"\n"}}{{end}}' "$SRC/daemon" "$SRC/atcd" "$SRC/api" "$SRC/atc_api" "$SRC/shaping" | sort -u | fgrep . | grep -v "augmented-traffic-control"
 }
 
-make_gopath
+if [ ! "$CI" == true ]; then
+    GOPATH="$(pwd)/.gopath/"
+    export GOPATH
+    make_gopath
+fi
 get_depends


### PR DESCRIPTION
After much tweaking, here is a travis ci spec that will allow running (almost all) the test suite in a vanilla env.
This will allow us to catch when we break the make file, tests...

It needs to run in a VM (I would have hoped it could run in a docker instance that would be faster).
Also, it needs to run in trusty distro due to some limitation in kernel 2.6.32 that is installed in the base precise image.
trusty vm is missing an ipv6 localhost which prevents us from running some of the tests. They are gated in Makefile.
https://travis-ci.org/chantra/augmented-traffic-control/builds/93099431
