### PR TITLE
Use docker in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,20 @@
 # sudo is required in order to be able to run src/shaping tests
 sudo: required
-# trusty is required to support setting up dummy interfaces with netlink
-dist: trusty
-language: go
-go:
-    - 1.5
-# Enforce upstream path
-go_import_path: github.com/facebook/augmented-traffic-control
-install:
-    # install dependencies
-    - ./setup.sh
-    # install assets
-    - make src/api/bindata.go
+services:
+    - docker
 
+env:
+    COMPOSE_VERSION: 1.5.0
+
+before_install:
+    - curl -L https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+    - chmod +x docker-compose
+    - sudo mv docker-compose /usr/local/bin
+
+script:
+    - docker-compose build atc
+    # install dependencies
+    - docker-compose run atc ./setup.sh
+    # install assets
+    - docker-compose run atc make src/api/bindata.go
+    - docker-compose run atc make

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ script:
     - docker-compose build atc
     # install dependencies
     - docker-compose run atc ./setup.sh
-    # install assets
-    - docker-compose run atc make src/api/bindata.go
+    # make binaries and test
     - docker-compose run atc make
+    - docker-compose run atc make tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,6 @@
 FROM golang:1.5.1
+RUN apt-get -y update; apt-get -y install rsyslog; systemctl enable rsyslog; apt-get -y clean
+
+COPY ./utils/docker_entrypoint.sh /
+ENTRYPOINT ["/docker_entrypoint.sh"]
+CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.5.1
-RUN apt-get -y update; apt-get -y install rsyslog; systemctl enable rsyslog; apt-get -y clean
+RUN apt-get -y update; apt-get -y install iptables rsyslog; systemctl enable rsyslog; apt-get -y clean
 
 COPY ./utils/docker_entrypoint.sh /
 ENTRYPOINT ["/docker_entrypoint.sh"]

--- a/HACKING.md
+++ b/HACKING.md
@@ -19,7 +19,7 @@ docker build -t atc .
 Once you have the image build, you can get a shell in the container by running:
 
 ```
-docker run -ti --rm --cap-add NET_ADMIN --cap-add SYS_ADMIN -v "$PWD":/usr/src/myapp -w /usr/src/myapp -p 9090:9090 -p 8080:8080 atc bash
+docker run -ti --rm --cap-add NET_ADMIN --cap-add SYS_ADMIN -v "$PWD":/usr/src/myapp -w /usr/src/myapp -p 9090:9090 -p 8080:8080 --env GOPATH=/usr/src/myapp/.gopath atc bash
 ```
 
 This will give you a bash prompt in the docker container and will set you in the working directory: `/usr/src/myapp`. The root of the atc project will be mounted within the container. From there, any chnages that you do in ATC repo, will be readily available in the container.

--- a/HACKING.md
+++ b/HACKING.md
@@ -19,7 +19,7 @@ docker build -t atc .
 Once you have the image build, you can get a shell in the container by running:
 
 ```
-docker run -ti --rm --cap-add NET_ADMIN --cap-add SYS_ADMIN --net host -v "$PWD":/usr/src/myapp -w /usr/src/myapp -p 9090:9090 -p 8080:8080 atc bash
+docker run -ti --rm --cap-add NET_ADMIN --cap-add SYS_ADMIN -v "$PWD":/usr/src/myapp -w /usr/src/myapp -p 9090:9090 -p 8080:8080 atc bash
 ```
 
 This will give you a bash prompt in the docker container and will set you in the working directory: `/usr/src/myapp`. The root of the atc project will be mounted within the container. From there, any chnages that you do in ATC repo, will be readily available in the container.
@@ -39,8 +39,7 @@ Once you have your development environment setup, you can build/install atcd by 
 
 ```
 ./setup.sh
-GOPATH="$(pwd)/.gopath/"
-export GOPATH
+export GOPATH="$(pwd)/.gopath/"
 make
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ STATIC_FILES = $(shell find static/ -print)
 USERID = $(shell id -u)
 
 .PHONY: all bin
-all: tests
+all: bin
 bin: bin/atcd bin/atc_api bin/atc
 
 bin/atcd: src/daemon/*.go src/atcd/*.go src/log/*.go src/shaping/*.go
@@ -49,7 +49,7 @@ bin/atc: src/log/*.go src/atc/*.go
 	$(BUILD) -o $@ ${SRC}/atc
 
 .PHONY: tests
-tests:
+tests: src/api/bindata.go
 	$(TEST) ${SRC}/daemon
 	@echo "[31mRunning shaping tests as root.[39m"
 ifeq ($(USERID),0)

--- a/Makefile
+++ b/Makefile
@@ -58,11 +58,7 @@ else
 	sudo PATH=${PATH} GOROOT=${GOROOT} GOPATH=${GOPATH} $(TEST) ${SRC}/shaping
 endif
 	$(TEST) ${SRC}/atcd
-# ::1 missing on TRAVIS VMS
-# https://github.com/travis-ci/travis-ci/issues/4964
-ifneq ($(TRAVIS),true)
 	$(TEST) ${SRC}/api
-endif
 	$(TEST) ${SRC}/atc_api
 
 src/api/bindata.go: $(STATIC_FILES)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # docker-compose spec allowing to run:
-# docker run -ti --rm --cap-add SYS_ADMIN --cap-add NET_ADMIN -v "$PWD":/usr/src/myapp -w /usr/src/myapp -p 9090:9090 -p 8080:8080 --env GOPATH="/usr/src/myapp/.gopath:$GOPATH" atc bash
+# docker run -ti --rm --cap-add SYS_ADMIN --cap-add NET_ADMIN -v "$PWD":/usr/src/myapp -w /usr/src/myapp -p 9090:9090 -p 8080:8080 --env GOPATH=/usr/src/myapp/.gopath atc bash
 # This is currently used to develop ATC and its test suite. While ATC itself
 # would only require NET_ADMIN capability, in order to be able to run test in
 # a new netns, we also need SYS_ADMIN capability.
@@ -10,7 +10,7 @@ atc:
         - .:/usr/src/myapp
     working_dir: /usr/src/myapp
     environment:
-        - GOPATH=/usr/src/myapp/.gopath:$GOPATH
+        - GOPATH=/usr/src/myapp/.gopath
     ports:
         - "9090:9090"
         - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # docker-compose spec allowing to run:
-# docker run -ti --rm --cap-add SYS_ADMIN --cap-add NET_ADMIN -v "$PWD":/usr/src/myapp -w /usr/src/myapp -p 9090:9090 -p 8080:8080 atc bash
+# docker run -ti --rm --cap-add SYS_ADMIN --cap-add NET_ADMIN -v "$PWD":/usr/src/myapp -w /usr/src/myapp -p 9090:9090 -p 8080:8080 --env GOPATH="/usr/src/myapp/.gopath:$GOPATH" atc bash
 # This is currently used to develop ATC and its test suite. While ATC itself
 # would only require NET_ADMIN capability, in order to be able to run test in
 # a new netns, we also need SYS_ADMIN capability.
@@ -9,6 +9,8 @@ atc:
     volumes:
         - .:/usr/src/myapp
     working_dir: /usr/src/myapp
+    environment:
+        - GOPATH=/usr/src/myapp/.gopath:$GOPATH
     ports:
         - "9090:9090"
         - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 # docker-compose spec allowing to run:
-# docker run -ti --rm --cap-add SYS_ADMIN --cap-add NET_ADMIN --net host -v "$PWD":/usr/src/myapp -w /usr/src/myapp -p 9090:9090 -p 8080:8080 atc bash
+# docker run -ti --rm --cap-add SYS_ADMIN --cap-add NET_ADMIN -v "$PWD":/usr/src/myapp -w /usr/src/myapp -p 9090:9090 -p 8080:8080 atc bash
 # This is currently used to develop ATC and its test suite. While ATC itself
 # would only require NET_ADMIN capability, in order to be able to run test in
 # a new netns, we also need SYS_ADMIN capability.
@@ -15,4 +15,3 @@ atc:
     cap_add:
         - NET_ADMIN # General TC/IP privileges
         - SYS_ADMIN # New NetNS Privilege
-    net: host

--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ get_depends() {
 depends() {
     # Special since it's a build-time dependency and isn't imported by any code
     echo "github.com/jteeuwen/go-bindata/go-bindata"
-    go list -f '{{range .Imports}}{{.}}{{"\n"}}{{end}}' "$SRC/daemon" "$SRC/atcd" "$SRC/api" "$SRC/atc_api" "$SRC/shaping" | sort -u | fgrep . | grep -v "augmented-traffic-control"
+    go list -f '{{range .Imports}}{{.}}{{"\n"}}{{end}}' "$SRC/daemon" "$SRC/atcd" "$SRC/atc" "$SRC/api" "$SRC/atc_api" "$SRC/shaping" | sort -u | fgrep . | grep -v "augmented-traffic-control"
 }
 
 if [ ! "$CI" == true ]; then

--- a/utils/docker_entrypoint.sh
+++ b/utils/docker_entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+# start up rsyslog
+/etc/init.d/rsyslog start
+# execute the command
+exec "$@"

--- a/utils/docker_entrypoint.sh
+++ b/utils/docker_entrypoint.sh
@@ -4,5 +4,7 @@ set -e
 
 # start up rsyslog
 /etc/init.d/rsyslog start
+# set up testing network namespaces
+bash utils/test-setup.sh 2>&1 > /dev/null
 # execute the command
 exec "$@"


### PR DESCRIPTION
Using docker in travis CI allows us to run all unittests again as we can have access to ::1 .