### PR TITLE
Get proxy address from requests

### DIFF
--- a/src/api/api_test.go
+++ b/src/api/api_test.go
@@ -242,6 +242,7 @@ func newTestServer(t *testing.T) testServer {
 		DBConn:      ":memory:",
 		V4:          "0.0.0.0",
 		V6:          "::",
+		ProxyAddr:   "",
 	}
 	srv, err := ListenAndServe(opts)
 	if err != nil {

--- a/src/api/server.go
+++ b/src/api/server.go
@@ -52,7 +52,6 @@ func ListenAndServe(options AtcApiOptions) (*Server, error) {
 			IP6:    options.V6,
 			Port:   strconv.Itoa(options.Addr.Port),
 		},
-		proxy_addr: proxy_addr,
 	}
 	srv.setupHandlers()
 	err = srv.ListenAndServe()

--- a/src/api/server.go
+++ b/src/api/server.go
@@ -21,6 +21,7 @@ type AtcApiOptions struct {
 	ThriftProto      string
 	DBDriver, DBConn string
 	V4, V6           string
+	ProxyAddr        string
 }
 
 type Server struct {
@@ -51,6 +52,7 @@ func ListenAndServe(options AtcApiOptions) (*Server, error) {
 			IP6:    options.V6,
 			Port:   strconv.Itoa(options.Addr.Port),
 		},
+		proxy_addr: proxy_addr,
 	}
 	srv.setupHandlers()
 	err = srv.ListenAndServe()

--- a/src/api/utils.go
+++ b/src/api/utils.go
@@ -142,29 +142,35 @@ func CORS(w http.ResponseWriter, methods ...string) {
 Gets the IP address of the client
 */
 func GetClientAddr(r *http.Request) string {
-	// FIXME: check headers for X_HTTP_CLIENT_IP or something
-	// FIXME: error handling (third return value)
 	srv := GetServer(r)
 	addr, _ := getProxiedClientAddr(srv, r)
 	return addr
 }
 
 func getProxiedClientAddr(srv *Server, r *http.Request) (string, error) {
-	srv_proxy := srv.proxy_addr
+	srv_proxy := srv.ProxyAddr
 	remote_addr, _, _ := net.SplitHostPort(r.RemoteAddr)
-	if real_ip, ok := r.Header["X_HTTP_REAL_IP"]; ok {
-		// Request was proxied
-		if srv_proxy == "" || srv_proxy == remote_addr {
-			if len(real_ip) == 0 {
-				return "", fmt.Errorf("Invalid proxy info")
-			}
+	real_ip, ok := r.Header["X_HTTP_REAL_IP"]
+	proxy_request := ok && (len(real_ip) == 1)
+	proxy_server := srv_proxy != ""
+	if proxy_request && proxy_server {
+		// Server and client were both proxied
+		if srv_proxy == remote_addr {
 			return real_ip[0], nil
 		} else {
-			Log.Printf("Invalid proxy address: %s", remote_addr)
+			Log.Printf("Unauthorized proxied request from %s on behalf of %v", remote_addr, real_ip[0])
 			return "", fmt.Errorf("Invalid proxy address")
 		}
+	} else if proxy_request {
+		// Client was proxied but the server wasn't
+		Log.Printf("Unexpected proxied request from %s on behalf of %v", remote_addr, real_ip[0])
+		return "", fmt.Errorf("Invalid proxy address")
+	} else if proxy_server {
+		// Server was proxied, but the client wasn't
+		Log.Printf("Unexpected non-proxied request from %s", remote_addr)
+		return "", fmt.Errorf("Invalid proxy address")
 	} else {
-		// Request was direct
+		// Neither the server nor the client were proxied.
 		return remote_addr, nil
 	}
 }

--- a/src/api/utils_test.go
+++ b/src/api/utils_test.go
@@ -75,3 +75,45 @@ func TestHandlesThrownError(t *testing.T) {
 		t.Errorf("Expected error message %q != %q", ServerError.Error(), actual_message)
 	}
 }
+
+func TestGetsProxiedAddr(t *testing.T) {
+	r, _ := http.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "1.1.1.1:1234"
+	srv := &Server{proxy_addr: ""}
+
+	// Non-proxied request should work
+	addr, err := getProxiedClientAddr(srv, r)
+	if err != nil {
+		t.Error(err)
+	} else if addr != "1.1.1.1" {
+		t.Errorf("Wrong proxy address: %q", addr)
+	}
+
+	// Simulate a proxied request
+	r.Header.Set("X_HTTP_REAL_IP", "2.2.2.2")
+
+	// Works without a proxy address set
+	addr, err = getProxiedClientAddr(srv, r)
+	if err != nil {
+		t.Error(err)
+	} else if addr != "2.2.2.2" {
+		t.Errorf("Wrong proxy address: %q", addr)
+	}
+
+	// Works with correct proxy address set
+	srv.proxy_addr = "1.1.1.1"
+	addr, err = getProxiedClientAddr(srv, r)
+	if err != nil {
+		t.Error(err)
+	} else if addr != "2.2.2.2" {
+		t.Errorf("Wrong proxy address: %q", addr)
+	}
+
+	srv.proxy_addr = "3.3.3.3"
+	r.RemoteAddr = "message.ok.in.tests:1234"
+	// Shouldn't work if proxy address is set wrong
+	_, err = getProxiedClientAddr(srv, r)
+	if err == nil {
+		t.Errorf("Proxy address should be invalid: %q", addr)
+	}
+}

--- a/src/api/utils_test.go
+++ b/src/api/utils_test.go
@@ -77,42 +77,40 @@ func TestHandlesThrownError(t *testing.T) {
 }
 
 func TestGetsProxiedAddr(t *testing.T) {
-	r, _ := http.NewRequest("GET", "/", nil)
-	r.RemoteAddr = "1.1.1.1:1234"
-	srv := &Server{proxy_addr: ""}
+	testProxy := func(client_addr, header_addr, server_addr string) (string, error) {
+		r, _ := http.NewRequest("GET", "/", nil)
+		r.RemoteAddr = client_addr + ":0" // net.SplitHostPort requires a port
+		if header_addr != "" {
+			r.Header.Set("X_HTTP_REAL_IP", header_addr)
+		}
+		srv := &Server{AtcApiOptions: AtcApiOptions{ProxyAddr: server_addr}}
+		return getProxiedClientAddr(srv, r)
+	}
 
-	// Non-proxied request should work
-	addr, err := getProxiedClientAddr(srv, r)
+	// Neither the server nor the client are proxied.
+	addr, err := testProxy("1.1.1.1", "", "")
 	if err != nil {
 		t.Error(err)
 	} else if addr != "1.1.1.1" {
 		t.Errorf("Wrong proxy address: %q", addr)
 	}
 
-	// Simulate a proxied request
-	r.Header.Set("X_HTTP_REAL_IP", "2.2.2.2")
-
-	// Works without a proxy address set
-	addr, err = getProxiedClientAddr(srv, r)
+	// Both the client and the server are proxied.
+	addr, err = testProxy("1.1.1.1", "2.2.2.2", "1.1.1.1")
 	if err != nil {
 		t.Error(err)
 	} else if addr != "2.2.2.2" {
 		t.Errorf("Wrong proxy address: %q", addr)
 	}
 
-	// Works with correct proxy address set
-	srv.proxy_addr = "1.1.1.1"
-	addr, err = getProxiedClientAddr(srv, r)
-	if err != nil {
-		t.Error(err)
-	} else if addr != "2.2.2.2" {
-		t.Errorf("Wrong proxy address: %q", addr)
+	// Server expects a proxy, but client doesn't send one
+	addr, err = testProxy("this.message.ok.in.tests", "", "2.2.2.2")
+	if err == nil {
+		t.Errorf("Proxy address should be invalid: %q", addr)
 	}
 
-	srv.proxy_addr = "3.3.3.3"
-	r.RemoteAddr = "message.ok.in.tests:1234"
-	// Shouldn't work if proxy address is set wrong
-	_, err = getProxiedClientAddr(srv, r)
+	// Client sends a proxy, but the server doesn't expect it
+	addr, err = testProxy("this.message.ok.in.tests", "2.2.2.2", "")
 	if err == nil {
 		t.Errorf("Proxy address should be invalid: %q", addr)
 	}

--- a/src/atc_api/main.go
+++ b/src/atc_api/main.go
@@ -65,6 +65,7 @@ func ParseArgs() Arguments {
 	kingpin.Flag("dbconn", "Database connection string").Short('Q').Default("atc_api.db").StringVar(&args.DBConn)
 	kingpin.Flag("ipv4", "IPv4 address (or hostname) of the ATC API").Short('4').Default("").StringVar(&args.DBConn)
 	kingpin.Flag("ipv6", "IPv6 address (or hostname) of the ATC API").Short('6').Default("").StringVar(&args.DBConn)
+	kingpin.Flag("proxy-addr", "IP address of authorized HTTP reverse proxy").Default("").StringVar(&args.ProxyAddr)
 	kingpin.Flag("warn", "Only warn if the thrift server isn't reachable").Short('Q').Default("false").BoolVar(&args.WarnOnly)
 	kingpin.Parse()
 


### PR DESCRIPTION
HTTP proxies can set `X_HTTP_REAL_IP` to specify the address of the client, rather than the `RemoteAddr` of the request, which will be the client.

If `-proxy-addr X` is provided to `atcd`, it will verify that the `RemoteAddr` matches the provided address  , or will fail.
