### PR TITLE
Cleaned up CLI args

### DIFF
--- a/src/api/api_test.go
+++ b/src/api/api_test.go
@@ -15,7 +15,9 @@ import (
 )
 
 // IP address for test server to bind to.
-var ServerAddr = ""
+// This IP address must be reachable from both the addresses provided below.
+// IPv4zero works for this since it actually binds to all ipv4 and ipv6 addresses
+var ServerAddr = net.IPv4zero
 
 // Client addresses to use to connect to atc.
 // Need to provide two in order to simulate two different clients connecting
@@ -229,7 +231,19 @@ type testServer struct {
 }
 
 func newTestServer(t *testing.T) testServer {
-	srv, err := ListenAndServe(net.JoinHostPort(ServerAddr, "0"), "", "", "sqlite3", ":memory:", "0.0.0.0", "::")
+	opts := AtcApiOptions{
+		Addr: &net.TCPAddr{
+			IP:   ServerAddr,
+			Port: 0,
+		},
+		ThriftAddr:  nil,
+		ThriftProto: "",
+		DBDriver:    "sqlite3",
+		DBConn:      ":memory:",
+		V4:          "0.0.0.0",
+		V6:          "::",
+	}
+	srv, err := ListenAndServe(opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/api/atc_connector.go
+++ b/src/api/atc_connector.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"net"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
 	"github.com/facebook/augmented-traffic-control/src/atc_thrift"
@@ -29,11 +30,11 @@ type AtcdCloser interface {
 type AtcdConn struct {
 	*atc_thrift.AtcdClient
 	xport        thrift.TTransport
-	thrift_addr  string
+	thrift_addr  *net.TCPAddr
 	thrift_proto string
 }
 
-func NewAtcdConn(thrift_addr, thrift_proto string) *AtcdConn {
+func NewAtcdConn(thrift_addr *net.TCPAddr, thrift_proto string) *AtcdConn {
 	return &AtcdConn{
 		thrift_addr:  thrift_addr,
 		thrift_proto: thrift_proto,
@@ -42,7 +43,7 @@ func NewAtcdConn(thrift_addr, thrift_proto string) *AtcdConn {
 
 func (atcd *AtcdConn) Open() error {
 	var err error
-	atcd.xport, err = thrift.NewTSocket(atcd.thrift_addr)
+	atcd.xport, err = thrift.NewTSocket(atcd.thrift_addr.String())
 	if err != nil {
 		return err
 	}

--- a/src/atc/main.go
+++ b/src/atc/main.go
@@ -105,7 +105,7 @@ func main() {
 
 	cmd := kingpin.Parse()
 
-	atcd = api.NewAtcdConn((*thriftAddr).String(), *thriftProto)
+	atcd = api.NewAtcdConn(*thriftAddr, *thriftProto)
 	if err := atcd.Open(); err != nil {
 		Log.Fatalln("Could not open connection to atcd:", err)
 	}

--- a/src/atc_api/main.go
+++ b/src/atc_api/main.go
@@ -23,7 +23,7 @@ func main() {
 	args := ParseArgs()
 
 	// Make sure connection to the daemon is working.
-	err := TestAtcdConnection(args.ThriftAddr, args.ThriftProtocol)
+	err := TestAtcdConnection(args.ThriftAddr, args.ThriftProto)
 	if err != nil {
 		api.Log.Println("failed to connect to atcd server:", err)
 		if !args.WarnOnly {
@@ -33,13 +33,13 @@ func main() {
 		api.Log.Println("Connected to atcd socket on", args.ThriftAddr)
 	}
 
-	if args.IPv4 == "" && args.IPv6 == "" {
+	if args.V4 == "" && args.V6 == "" {
 		api.Log.Fatalln("You must provide either -4 or -6 arguments to run the API.")
 	}
 
-	api.Log.Println("Listening on", args.BindAddr)
+	api.Log.Println("Listening on", args.Addr)
 
-	srv, err := api.ListenAndServe(args.BindAddr, args.ThriftAddr, args.ThriftProtocol, args.DbDriver, args.DbConnstr, args.IPv4, args.IPv6)
+	srv, err := api.ListenAndServe(args.AtcApiOptions)
 	if err != nil {
 		api.Log.Fatalln("failed to listen and serve:", err)
 	}
@@ -51,14 +51,8 @@ func main() {
 }
 
 type Arguments struct {
-	BindAddr       string
-	ThriftAddr     string
-	ThriftProtocol string
-	DbDriver       string
-	DbConnstr      string
-	WarnOnly       bool
-	IPv4           string
-	IPv6           string
+	api.AtcApiOptions
+	WarnOnly bool
 }
 
 func ParseArgs() Arguments {
@@ -73,13 +67,15 @@ func ParseArgs() Arguments {
 	flag.Parse()
 
 	return Arguments{
-		BindAddr:       *bindAddr,
-		ThriftAddr:     *thriftAddr,
-		ThriftProtocol: *proto,
-		DbDriver:       *db_driver,
-		DbConnstr:      *db_connstr,
-		WarnOnly:       *warn_only,
-		IPv4:           *ipv4,
-		IPv6:           *ipv6,
+		AtcApiOptions: api.AtcApiOptions{
+			Addr:        *bindAddr,
+			ThriftAddr:  *thriftAddr,
+			ThriftProto: *proto,
+			DBDriver:    *db_driver,
+			DBConn:      *db_connstr,
+			V4:          *ipv4,
+			V6:          *ipv6,
+		},
+		WarnOnly: *warn_only,
 	}
 }

--- a/src/atc_api/main.go
+++ b/src/atc_api/main.go
@@ -1,11 +1,11 @@
 package main
 
 import (
-	"flag"
 	"os"
 	"time"
 
 	"github.com/facebook/augmented-traffic-control/src/api"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 func TestAtcdConnection(addr, proto string) error {
@@ -56,26 +56,18 @@ type Arguments struct {
 }
 
 func ParseArgs() Arguments {
-	bindAddr := flag.String("b", "0.0.0.0:8080", "Bind address")
-	thriftAddr := flag.String("t", "127.0.0.1:9090", "Thrift server address")
-	proto := flag.String("p", "json", "Thrift protocol")
-	db_driver := flag.String("D", "sqlite3", "database driver")
-	db_connstr := flag.String("Q", "atc_api.db", "database driver connection parameters")
-	warn_only := flag.Bool("W", false, "only warn if the thrift server isn't reachable")
-	ipv4 := flag.String("4", "", "IPv4 address for the API")
-	ipv6 := flag.String("6", "", "IPv6 address for the API")
-	flag.Parse()
+	args := Arguments{}
+	// FIXME: this should be a TCPVar
+	kingpin.Flag("listen", "Bind address for the HTTP server").Short('b').Default("0.0.0.0:8080").StringVar(&args.Addr)
+	// FIXME: this should be a TCPVar
+	kingpin.Flag("atcd", "ATCD thrift server address").Short('t').Default("127.0.0.1:9090").StringVar(&args.ThriftAddr)
+	kingpin.Flag("atcd-proto", "ATCD thrift server protocol").Short('p').Default("json").StringVar(&args.ThriftProto)
+	kingpin.Flag("dbdrv", "Database driver").Short('D').Default("sqlite3").StringVar(&args.DBDriver)
+	kingpin.Flag("dbconn", "Database connection string").Short('Q').Default("atc_api.db").StringVar(&args.DBConn)
+	kingpin.Flag("ipv4", "IPv4 address (or hostname) of the ATC API").Short('4').Default("").StringVar(&args.DBConn)
+	kingpin.Flag("ipv6", "IPv6 address (or hostname) of the ATC API").Short('6').Default("").StringVar(&args.DBConn)
+	kingpin.Flag("warn", "Only warn if the thrift server isn't reachable").Short('Q').Default("false").BoolVar(&args.WarnOnly)
+	kingpin.Parse()
 
-	return Arguments{
-		AtcApiOptions: api.AtcApiOptions{
-			Addr:        *bindAddr,
-			ThriftAddr:  *thriftAddr,
-			ThriftProto: *proto,
-			DBDriver:    *db_driver,
-			DBConn:      *db_connstr,
-			V4:          *ipv4,
-			V6:          *ipv6,
-		},
-		WarnOnly: *warn_only,
-	}
+	return args
 }

--- a/src/atc_api/main.go
+++ b/src/atc_api/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net"
 	"os"
 	"time"
 
@@ -8,7 +9,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-func TestAtcdConnection(addr, proto string) error {
+func TestAtcdConnection(addr *net.TCPAddr, proto string) error {
 	atcd := api.NewAtcdConn(addr, proto)
 	if err := atcd.Open(); err != nil {
 		return err
@@ -57,10 +58,8 @@ type Arguments struct {
 
 func ParseArgs() Arguments {
 	args := Arguments{}
-	// FIXME: this should be a TCPVar
-	kingpin.Flag("listen", "Bind address for the HTTP server").Short('b').Default("0.0.0.0:8080").StringVar(&args.Addr)
-	// FIXME: this should be a TCPVar
-	kingpin.Flag("atcd", "ATCD thrift server address").Short('t').Default("127.0.0.1:9090").StringVar(&args.ThriftAddr)
+	kingpin.Flag("listen", "Bind address for the HTTP server").Short('b').Default("0.0.0.0:8080").TCPVar(&args.Addr)
+	kingpin.Flag("atcd", "ATCD thrift server address").Short('t').Default("127.0.0.1:9090").TCPVar(&args.ThriftAddr)
 	kingpin.Flag("atcd-proto", "ATCD thrift server protocol").Short('p').Default("json").StringVar(&args.ThriftProto)
 	kingpin.Flag("dbdrv", "Database driver").Short('D').Default("sqlite3").StringVar(&args.DBDriver)
 	kingpin.Flag("dbconn", "Database connection string").Short('Q').Default("atc_api.db").StringVar(&args.DBConn)

--- a/src/shaping/shaping_linux.go
+++ b/src/shaping/shaping_linux.go
@@ -1,13 +1,14 @@
 package shaping
 
 import (
-	"flag"
 	"fmt"
 	"math"
 	"net"
 	"os/exec"
 	"strings"
 	"syscall"
+
+	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/facebook/augmented-traffic-control/src/atc_thrift"
 	"github.com/vishvananda/netlink"
@@ -29,10 +30,10 @@ var (
 Sets up platform-specific flags for the shaper.
 */
 func ShapingFlags() {
-	flag.StringVar(&IPTABLES, "iptables", "", "iptables binary location")
-	flag.StringVar(&IP6TABLES, "ip6tables", "", "ip6tables binary location")
-	flag.StringVar(&WAN_INT, "wan", "eth0", "ATCD WAN interface")
-	flag.StringVar(&LAN_INT, "lan", "eth1", "ATCD LAN interface")
+	kingpin.Flag("iptables", "location of the iptables binary").StringVar(&IPTABLES)
+	kingpin.Flag("ip6tables", "location of the ip6tables binary").StringVar(&IP6TABLES)
+	kingpin.Flag("wan", "name of the WAN interface").StringVar(&WAN_INT)
+	kingpin.Flag("lan", "name of the LAN interface").StringVar(&LAN_INT)
 }
 
 /*


### PR DESCRIPTION
- Cleaned up how the `api` module accepts arguments.
- Switched to using [kingpin](https://github.com/alecthomas/kingpin) instead of flag for argument parsing.
  This allows long arguments (e.g. `--iptables`), and better validation on arguments with known types (e.g. `*net.IP`).
- Parse several options as `*net.TCPAddr` instead of as string, allowing better checking on those arguments.

[output of `--help`](https://gist.github.com/zfjagann/1a6c16acb596c29bf944)
