### PR TITLE
Travis matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
               - src/react/node_modules
           script:
             - make npm_env
+            - make jsx-lint
             - make jsx
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,26 @@ sudo: required
 services:
     - docker
 
-env:
-    COMPOSE_VERSION: 1.5.0
+language: go
+go:
+    - tip
+
+env: COMPOSE_VERSION=1.5.0
 
 before_install:
     - curl -L https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
     - chmod +x docker-compose
     - sudo mv docker-compose /usr/local/bin
+
+matrix:
+    include:
+        - go: tip
+          env: COMPOSE_VERSION=1.5.0
+          dist: trusty
+          script:
+            - docker-compose build node
+            - docker-compose run node make npm_env
+            - docker-compose run node make jsx
 
 script:
     - docker-compose build atc

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
           sudo: false
           env: COMPOSE_VERSION=1.5.0
           before_install:
+          cache:
+            directories:
+              - src/react/node_modules
           script:
             - make npm_env
             - make jsx

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: required
 services:
     - docker
 
-language: go
-go:
-    - tip
+language: node_js
+node_js:
+    - "4.1"
 
 env: COMPOSE_VERSION=1.5.0
 
@@ -16,13 +16,13 @@ before_install:
 
 matrix:
     include:
-        - go: tip
+        - node_js: "4.1"
+          sudo: false
           env: COMPOSE_VERSION=1.5.0
-          dist: trusty
+          before_install:
           script:
-            - docker-compose build node
-            - docker-compose run node make npm_env
-            - docker-compose run node make jsx
+            - make npm_env
+            - make jsx
 
 script:
     - docker-compose build atc

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ jsx: src/react/jsx/*.js
 	cd src/react && $(NPM) run build-js
 
 jsx-lint:
-	@cd src/react && $(NPM) run lint
+	cd src/react && $(NPM) run lint
 
 npm_env:
 	cd src/react && $(NPM) install

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ bin/atc: src/log/*.go src/atc/*.go
 jsx: src/react/jsx/*.js
 	cd src/react && $(NPM) run build-js
 
+jsx-lint:
+	@cd src/react && $(NPM) run lint
+
 npm_env:
 	cd src/react && $(NPM) install
 

--- a/src/react/package.json
+++ b/src/react/package.json
@@ -44,7 +44,8 @@
     "test": "jest",
     "build-jsx": "babel jsx --out-dir build",
     "build-js": "browserify -t [ babelify --presets [ es2015 react ] ] jsx/index.js > ../../static/js/index.js",
-    "watch": "watchify --poll -v -t babelify jsx/ -o ../../static/js/index.js"
+    "watch": "watchify --poll -v -t babelify jsx/ -o ../../static/js/index.js",
+    "lint": "eslint jsx/*.js"
   },
   "jest": {
     "scriptPreprocessor": "<rootDir>/node_modules/babel-jest",


### PR DESCRIPTION
Spin up 2 builds, 1 for go stuff and 1 for JS.
Run the JS build in travis docker containers as we dont need root access and also take advantage of caching.
No JS unittest yet, but it will build the JS from JSX files and run lint.