### PR TITLE
[atc_api] Properly set context for index page

### DIFF
--- a/src/api/api_test.go
+++ b/src/api/api_test.go
@@ -28,6 +28,19 @@ var ServerAddr = net.IPv4zero
 var Addr1 = "::1"
 var Addr2 = "127.0.0.1"
 
+// Test that we can fetch the index page
+func TestIndex(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Cleanup()
+	cli := srv.client(Addr1)
+
+	resp := cli.GetIndex()
+
+	if resp.StatusCode != 200 {
+		t.Error("Wrong status code:", resp.StatusCode)
+	}
+}
+
 func TestGetsServerInfo(t *testing.T) {
 	srv := newTestServer(t)
 	defer srv.Cleanup()
@@ -281,6 +294,14 @@ func (c testClient) Get(version int, url string) *http.Response {
 	resp, err := http.Get(fmt.Sprintf("http://%s/api/v%d%s", c.addr, version, url))
 	if err != nil {
 		c.t.Fatalf("Couldn't fetch url %q: %v", url, err)
+	}
+	return resp
+}
+
+func (c testClient) GetIndex() *http.Response {
+	resp, err := http.Get(fmt.Sprintf("http://%s/", c.addr))
+	if err != nil {
+		c.t.Fatalf("Couldn't fetch url /: %v", err)
 	}
 	return resp
 }

--- a/src/api/assets.go
+++ b/src/api/assets.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/http"
 
+	"github.com/gorilla/context"
 	"github.com/gorilla/mux"
 )
 
@@ -65,7 +66,7 @@ func (info *bindInfo) templateFor(r *http.Request) *templateData {
 	return data
 }
 
-func rootHandler(info *bindInfo) http.HandlerFunc {
+func rootHandler(srv *Server) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		data, err := Asset("static/index.htm")
 		if err != nil {
@@ -73,6 +74,7 @@ func rootHandler(info *bindInfo) http.HandlerFunc {
 			w.WriteHeader(404)
 			return
 		}
+		context.Set(r, srv_context_key, srv)
 		tmpl, err := template.New("root").Parse(string(data))
 		if err != nil {
 			fmt.Println(err)
@@ -80,7 +82,7 @@ func rootHandler(info *bindInfo) http.HandlerFunc {
 			return
 		}
 		w.WriteHeader(200)
-		tmpl.Execute(w, info.templateFor(r))
+		tmpl.Execute(w, srv.bind_info.templateFor(r))
 	}
 }
 

--- a/src/api/server.go
+++ b/src/api/server.go
@@ -117,7 +117,7 @@ func (srv *Server) setupHandlers() {
 		apir.HandleFunc(url, h)
 		apir.HandleFunc(url+"/", h)
 	}
-	r.HandleFunc("/", rootHandler(srv.bind_info))
+	r.HandleFunc("/", rootHandler(srv))
 	r.HandleFunc("/static/{folder}/{name}", cachedAssetHandler)
 	srv.Handler = r
 }

--- a/src/api/utils.go
+++ b/src/api/utils.go
@@ -31,6 +31,7 @@ func GetAtcd(r *http.Request) atc_thrift.Atcd {
 	if rv := context.Get(r, atcd_context_key); rv != nil {
 		return rv.(atc_thrift.Atcd)
 	}
+	log.Printf("Error: could not GetAtcd for request %v\n", r)
 	return nil
 }
 
@@ -38,6 +39,7 @@ func GetServer(r *http.Request) *Server {
 	if rv := context.Get(r, srv_context_key); rv != nil {
 		return rv.(*Server)
 	}
+	log.Printf("Error: could not GetServer for request %v\n", r)
 	return nil
 }
 
@@ -45,6 +47,7 @@ func GetDB(r *http.Request) *DbRunner {
 	if rv := context.Get(r, db_context_key); rv != nil {
 		return rv.(*DbRunner)
 	}
+	log.Printf("Error: could not GetDB for request %v\n", r)
 	return nil
 }
 


### PR DESCRIPTION
Fixes #204

Accessing the index page was failing with error below.
Fixes the error and add unittest:
https://gist.github.com/chantra/78c4dba2cbf972974e72

goroutine 25 [running]:
net/http.(_conn).serve.func1(0xc8201493f0, 0x7f0ff586ba10, 0xc820024468)
    /usr/local/go/src/net/http/server.go:1287 +0xb5
github.com/facebook/augmented-traffic-control/src/api.getProxiedClientAddr(0x0,
0xc8203a4a80, 0x0, 0x0, 0x0, 0x0)
    /usr/src/myapp/.gopath/src/github.com/facebook/augmented-traffic-control/src/api/utils.go:156
+0x7b1
github.com/facebook/augmented-traffic-control/src/api.GetClientAddr(0xc8203a4a80,
0x0, 0x0)
    /usr/src/myapp/.gopath/src/github.com/facebook/augmented-traffic-control/src/api/utils.go:151
+0x61
github.com/facebook/augmented-traffic-control/src/api.bindInfo.getPrimarySecondaryAddrs(0x9ecec8,
0x7, 0x7fff73955e72, 0xe, 0x0, 0x0, 0xc82000ff00, 0x4, 0xc8203a4a80,
0x0, ...)
    /usr/src/myapp/.gopath/src/github.com/facebook/augmented-traffic-control/src/api/assets.go:20
+0x50
github.com/facebook/augmented-traffic-control/src/api.(_bindInfo).templateFor(0xc8200109c0,
0xc8203a4a80, 0x833)
    /usr/src/myapp/.gopath/src/github.com/facebook/augmented-traffic-control/src/api/assets.go:56
+0xb4
github.com/facebook/augmented-traffic-control/src/api.rootHandler.func1(0x7f0ff586c1b0,
0xc8201494a0, 0xc8203a4a80)
    /usr/src/myapp/.gopath/src/github.com/facebook/augmented-traffic-control/src/api/assets.go:83
+0x676
net/http.HandlerFunc.ServeHTTP(0xc820138ad0, 0x7f0ff586c1b0,
0xc8201494a0, 0xc8203a4a80)
    /usr/local/go/src/net/http/server.go:1422 +0x3a
github.com/gorilla/mux.(_Router).ServeHTTP(0xc820014a00, 0x7f0ff586c1b0,
0xc8201494a0, 0xc8203a4a80)
    /usr/src/myapp/.gopath/src/github.com/gorilla/mux/mux.go:100 +0x29e
net/http.serverHandler.ServeHTTP(0xc82013a540, 0x7f0ff586c1b0,
0xc8201494a0, 0xc8203a4a80)
    /usr/local/go/src/net/http/server.go:1862 +0x19e
net/http.(_conn).serve(0xc8201493f0)
    /usr/local/go/src/net/http/server.go:1361 +0xbee
created by net/http.(*Server).Serve
    /usr/local/go/src/net/http/server.go:1910 +0x3f6
