### PR TITLE
[atc_api] add unittest for cmdline

### DIFF
--- a/src/atc_api/main.go
+++ b/src/atc_api/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"net"
 	"os"
 	"time"
@@ -34,8 +35,8 @@ func main() {
 		api.Log.Println("Connected to atcd socket on", args.ThriftAddr)
 	}
 
-	if args.V4 == "" && args.V6 == "" {
-		api.Log.Fatalln("You must provide either -4 or -6 arguments to run the API.")
+	if err := validateArgs(args); err != nil {
+		api.Log.Fatalln(err)
 	}
 
 	api.Log.Println("Listening on", args.Addr)
@@ -49,6 +50,16 @@ func main() {
 		// Let the server run
 		time.Sleep(100 * time.Second)
 	}
+}
+
+func validateArgs(args Arguments) error {
+	if args.V4 == "" && args.V6 == "" {
+		return errors.New(
+			"You must provide either -4 or -6 arguments to run the API.",
+		)
+	}
+
+	return nil
 }
 
 type Arguments struct {

--- a/src/atc_api/main_test.go
+++ b/src/atc_api/main_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func handleValidateArgs(t *testing.T, cmd []string, shouldfail bool) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+	os.Args = cmd
+	args := ParseArgs()
+	if err := validateArgs(args); err != nil && !shouldfail {
+		t.Fatal(err)
+	}
+}
+
+func TestOnlyIPV4Provided(t *testing.T) {
+	handleValidateArgs(
+		t,
+		[]string{"cmd", "-4", "ipv4"},
+		false,
+	)
+}
+
+func TestOnlyIPV6Provided(t *testing.T) {
+	handleValidateArgs(
+		t,
+		[]string{"cmd", "-6", "ipv6"},
+		false,
+	)
+}
+
+func TestIPV4IPV6Provided(t *testing.T) {
+	handleValidateArgs(
+		t,
+		[]string{"cmd", "-4", "ipv4", "-6", "ipv6"},
+		false,
+	)
+}
+
+func TestNoIPProvided(t *testing.T) {
+	handleValidateArgs(t, []string{"cmd"}, true)
+}


### PR DESCRIPTION
```
/usr/local/go/bin/go test -v github.com/facebook/augmented-traffic-control/src/atc_api
=== RUN   TestOnlyIPV4Provided
--- PASS: TestOnlyIPV4Provided (0.00s)
=== RUN   TestOnlyIPV6Provided
--- PASS: TestOnlyIPV6Provided (0.00s)
=== RUN   TestIPV4IPV6Provided
--- PASS: TestIPV4IPV6Provided (0.00s)
=== RUN   TestNoIPProvided
--- PASS: TestNoIPProvided (0.00s)
```
