### PR TITLE
Use net.IP instead of string

### DIFF
--- a/src/api/api.go
+++ b/src/api/api.go
@@ -58,7 +58,7 @@ func InfoHandler(w http.ResponseWriter, r *http.Request) (interface{}, HttpError
 				Version:  daemon_info.Version,
 			},
 			Client: ClientInfo{
-				Addr:      addr,
+				Addr:      addr.String(),
 				Primary:   p,
 				Secondary: s,
 			},
@@ -80,7 +80,7 @@ func GroupsHandler(w http.ResponseWriter, r *http.Request) (interface{}, HttpErr
 		if cerr != nil {
 			return nil, cerr
 		}
-		grp, err := atcd.CreateGroup(addr)
+		grp, err := atcd.CreateGroup(addr.String())
 		if err != nil {
 			return nil, HttpErrorf(http.StatusBadGateway, "Could not create group: %v", err)
 		}
@@ -94,7 +94,7 @@ func GroupsHandler(w http.ResponseWriter, r *http.Request) (interface{}, HttpErr
 		if cerr != nil {
 			return nil, cerr
 		}
-		group, err := atcd.GetGroupWith(addr)
+		group, err := atcd.GetGroupWith(addr.String())
 		if err != nil {
 			// No group found.
 			return nil, nil
@@ -148,13 +148,13 @@ func GroupJoinHandler(w http.ResponseWriter, r *http.Request) (interface{}, Http
 		if cerr != nil {
 			return nil, cerr
 		}
-		err = atcd.JoinGroup(id, member, req_info.Token)
+		err = atcd.JoinGroup(id, member.String(), req_info.Token)
 		if err != nil {
 			return nil, HttpErrorf(http.StatusBadGateway, "Could not join group: %v", err)
 		}
 		return MemberResponse{
 			Id:     id,
-			Member: member,
+			Member: member.String(),
 		}, nil
 	case "OPTIONS":
 		return nil, nil
@@ -180,13 +180,13 @@ func GroupLeaveHandler(w http.ResponseWriter, r *http.Request) (interface{}, Htt
 		if cerr != nil {
 			return nil, cerr
 		}
-		err = atcd.LeaveGroup(id, member, req_info.Token)
+		err = atcd.LeaveGroup(id, member.String(), req_info.Token)
 		if err != nil {
 			return nil, HttpErrorf(http.StatusBadGateway, "Could not join group: %v", err)
 		}
 		return MemberResponse{
 			Id:     id,
-			Member: member,
+			Member: member.String(),
 		}, nil
 	case "OPTIONS":
 		return nil, nil
@@ -208,7 +208,7 @@ func GroupTokenHandler(w http.ResponseWriter, r *http.Request) (interface{}, Htt
 		if err != nil {
 			return nil, HttpErrorf(http.StatusNotAcceptable, "Could not get ID from url: %v", err)
 		}
-		grp, err := atcd.GetGroupWith(addr)
+		grp, err := atcd.GetGroupWith(addr.String())
 		if err != nil {
 			if IsNoSuchItem(err) {
 				return nil, HttpErrorf(http.StatusUnauthorized, "Invalid group")
@@ -303,7 +303,7 @@ func getSimpleShaping(atcd atc_thrift.Atcd, w http.ResponseWriter, r *http.Reque
 	if cerr != nil {
 		return nil, cerr
 	}
-	group, err := atcd.GetGroupWith(addr)
+	group, err := atcd.GetGroupWith(addr.String())
 	if err != nil {
 		// Not being shaped
 		return nil, nil
@@ -319,9 +319,9 @@ func createSimpleShaping(atcd atc_thrift.Atcd, w http.ResponseWriter, r *http.Re
 	if cerr != nil {
 		return nil, cerr
 	}
-	group, err := atcd.GetGroupWith(addr)
+	group, err := atcd.GetGroupWith(addr.String())
 	if err != nil {
-		group, err = atcd.CreateGroup(addr)
+		group, err = atcd.CreateGroup(addr.String())
 		if err != nil {
 			return nil, HttpErrorf(http.StatusBadGateway, "Could not create group: %v", err)
 		}
@@ -352,7 +352,7 @@ func deleteSimpleShaping(atcd atc_thrift.Atcd, w http.ResponseWriter, r *http.Re
 	if cerr != nil {
 		return nil, cerr
 	}
-	group, err := atcd.GetGroupWith(addr)
+	group, err := atcd.GetGroupWith(addr.String())
 	if err != nil {
 		return nil, HttpErrorf(http.StatusNotFound, "Address not being shaped")
 	}

--- a/src/api/api.go
+++ b/src/api/api.go
@@ -39,11 +39,18 @@ func InfoHandler(w http.ResponseWriter, r *http.Request) (interface{}, HttpError
 	case "GET":
 		serv := GetServer(r)
 		atcd := GetAtcd(r)
+		addr, cerr := GetClientAddr(r)
+		if cerr != nil {
+			return nil, cerr
+		}
 		daemon_info, err := atcd.GetAtcdInfo()
 		if err != nil {
 			return nil, HttpErrorf(http.StatusBadGateway, "Could not communicate with ATC Daemon: %v", err)
 		}
-		p, s := serv.bind_info.getPrimarySecondaryAddrs(r)
+		p, s, cerr := serv.bind_info.getPrimarySecondaryAddrs(r)
+		if cerr != nil {
+			return nil, cerr
+		}
 		info := ServerInfo{
 			Api: serv.GetInfo(r),
 			Atcd: DaemonInfo{
@@ -51,7 +58,7 @@ func InfoHandler(w http.ResponseWriter, r *http.Request) (interface{}, HttpError
 				Version:  daemon_info.Version,
 			},
 			Client: ClientInfo{
-				Addr:      GetClientAddr(r),
+				Addr:      addr,
 				Primary:   p,
 				Secondary: s,
 			},
@@ -69,7 +76,11 @@ func GroupsHandler(w http.ResponseWriter, r *http.Request) (interface{}, HttpErr
 	atcd := GetAtcd(r)
 	switch r.Method {
 	case "POST":
-		grp, err := atcd.CreateGroup(GetClientAddr(r))
+		addr, cerr := GetClientAddr(r)
+		if cerr != nil {
+			return nil, cerr
+		}
+		grp, err := atcd.CreateGroup(addr)
 		if err != nil {
 			return nil, HttpErrorf(http.StatusBadGateway, "Could not create group: %v", err)
 		}
@@ -79,7 +90,10 @@ func GroupsHandler(w http.ResponseWriter, r *http.Request) (interface{}, HttpErr
 		}
 		return CreatedGroup{grp, token}, nil
 	case "GET":
-		addr := GetClientAddr(r)
+		addr, cerr := GetClientAddr(r)
+		if cerr != nil {
+			return nil, cerr
+		}
 		group, err := atcd.GetGroupWith(addr)
 		if err != nil {
 			// No group found.
@@ -130,7 +144,10 @@ func GroupJoinHandler(w http.ResponseWriter, r *http.Request) (interface{}, Http
 		if err := json.NewDecoder(r.Body).Decode(req_info); err != nil {
 			return nil, HttpErrorf(http.StatusNotAcceptable, "Could not parse json from request: %v", err)
 		}
-		member := GetClientAddr(r)
+		member, cerr := GetClientAddr(r)
+		if cerr != nil {
+			return nil, cerr
+		}
 		err = atcd.JoinGroup(id, member, req_info.Token)
 		if err != nil {
 			return nil, HttpErrorf(http.StatusBadGateway, "Could not join group: %v", err)
@@ -159,7 +176,10 @@ func GroupLeaveHandler(w http.ResponseWriter, r *http.Request) (interface{}, Htt
 		if err := json.NewDecoder(r.Body).Decode(req_info); err != nil {
 			return nil, HttpErrorf(http.StatusNotAcceptable, "Could not parse json from request: %v", err)
 		}
-		member := GetClientAddr(r)
+		member, cerr := GetClientAddr(r)
+		if cerr != nil {
+			return nil, cerr
+		}
 		err = atcd.LeaveGroup(id, member, req_info.Token)
 		if err != nil {
 			return nil, HttpErrorf(http.StatusBadGateway, "Could not join group: %v", err)
@@ -180,11 +200,15 @@ func GroupTokenHandler(w http.ResponseWriter, r *http.Request) (interface{}, Htt
 	atcd := GetAtcd(r)
 	switch r.Method {
 	case "GET":
+		addr, cerr := GetClientAddr(r)
+		if cerr != nil {
+			return nil, cerr
+		}
 		id, err := strconv.ParseInt(mux.Vars(r)["id"], 10, 64)
 		if err != nil {
 			return nil, HttpErrorf(http.StatusNotAcceptable, "Could not get ID from url: %v", err)
 		}
-		grp, err := atcd.GetGroupWith(GetClientAddr(r))
+		grp, err := atcd.GetGroupWith(addr)
 		if err != nil {
 			if IsNoSuchItem(err) {
 				return nil, HttpErrorf(http.StatusUnauthorized, "Invalid group")
@@ -275,7 +299,10 @@ func ShapeHandler(w http.ResponseWriter, r *http.Request) (interface{}, HttpErro
 }
 
 func getSimpleShaping(atcd atc_thrift.Atcd, w http.ResponseWriter, r *http.Request) (interface{}, HttpError) {
-	addr := GetClientAddr(r)
+	addr, cerr := GetClientAddr(r)
+	if cerr != nil {
+		return nil, cerr
+	}
 	group, err := atcd.GetGroupWith(addr)
 	if err != nil {
 		// Not being shaped
@@ -288,7 +315,10 @@ func getSimpleShaping(atcd atc_thrift.Atcd, w http.ResponseWriter, r *http.Reque
 }
 
 func createSimpleShaping(atcd atc_thrift.Atcd, w http.ResponseWriter, r *http.Request) (interface{}, HttpError) {
-	addr := GetClientAddr(r)
+	addr, cerr := GetClientAddr(r)
+	if cerr != nil {
+		return nil, cerr
+	}
 	group, err := atcd.GetGroupWith(addr)
 	if err != nil {
 		group, err = atcd.CreateGroup(addr)
@@ -318,7 +348,10 @@ func createSimpleShaping(atcd atc_thrift.Atcd, w http.ResponseWriter, r *http.Re
 }
 
 func deleteSimpleShaping(atcd atc_thrift.Atcd, w http.ResponseWriter, r *http.Request) (interface{}, HttpError) {
-	addr := GetClientAddr(r)
+	addr, cerr := GetClientAddr(r)
+	if cerr != nil {
+		return nil, cerr
+	}
 	group, err := atcd.GetGroupWith(addr)
 	if err != nil {
 		return nil, HttpErrorf(http.StatusNotFound, "Address not being shaped")

--- a/src/api/assets.go
+++ b/src/api/assets.go
@@ -25,7 +25,7 @@ func (info bindInfo) getPrimarySecondaryAddrs(r *http.Request) (primary, seconda
 	}
 	if info.IP6 != "" && info.IP4 != "" {
 		// server is dual-stack
-		if p := net.ParseIP(addr); p.To4() == nil {
+		if addr.To4() == nil {
 			// client is ipv6
 			primary = info.IP6
 			secondary = info.IP4

--- a/src/api/assets.go
+++ b/src/api/assets.go
@@ -18,8 +18,11 @@ type bindInfo struct {
 	Port   string
 }
 
-func (info bindInfo) getPrimarySecondaryAddrs(r *http.Request) (primary, secondary string) {
-	addr := GetClientAddr(r)
+func (info bindInfo) getPrimarySecondaryAddrs(r *http.Request) (primary, secondary string, err HttpError) {
+	addr, err := GetClientAddr(r)
+	if err != nil {
+		return "", "", err
+	}
 	if info.IP6 != "" && info.IP4 != "" {
 		// server is dual-stack
 		if p := net.ParseIP(addr); p.To4() == nil {
@@ -51,11 +54,15 @@ type templateData struct {
 	Secondary string
 }
 
-func (info *bindInfo) templateFor(r *http.Request) *templateData {
+func (info *bindInfo) templateFor(r *http.Request) (*templateData, HttpError) {
 	data := &templateData{
 		ApiUrl: info.ApiUrl,
 	}
-	data.Primary, data.Secondary = info.getPrimarySecondaryAddrs(r)
+	var err HttpError
+	data.Primary, data.Secondary, err = info.getPrimarySecondaryAddrs(r)
+	if err != nil {
+		return nil, err
+	}
 	// If the user didn't provide one of the two addresses, we pass the UI an
 	// empty string.
 	if data.Primary != "" {
@@ -64,7 +71,7 @@ func (info *bindInfo) templateFor(r *http.Request) *templateData {
 	if data.Secondary != "" {
 		data.Secondary = net.JoinHostPort(data.Secondary, info.Port)
 	}
-	return data
+	return data, nil
 }
 
 func rootHandler(srv *Server) http.HandlerFunc {
@@ -82,8 +89,14 @@ func rootHandler(srv *Server) http.HandlerFunc {
 			w.WriteHeader(500)
 			return
 		}
+		tmpl_data, err := srv.bind_info.templateFor(r)
+		if err != nil {
+			fmt.Println(err)
+			w.WriteHeader(400)
+			return
+		}
 		w.WriteHeader(200)
-		tmpl.Execute(w, srv.bind_info.templateFor(r))
+		tmpl.Execute(w, tmpl_data)
 	}
 }
 

--- a/src/api/utils.go
+++ b/src/api/utils.go
@@ -144,12 +144,12 @@ func CORS(w http.ResponseWriter, methods ...string) {
 /*
 Gets the IP address of the client
 */
-func GetClientAddr(r *http.Request) (string, HttpError) {
+func GetClientAddr(r *http.Request) (net.IP, HttpError) {
 	srv := GetServer(r)
 	return getProxiedClientAddr(srv, r)
 }
 
-func getProxiedClientAddr(srv *Server, r *http.Request) (string, HttpError) {
+func getProxiedClientAddr(srv *Server, r *http.Request) (net.IP, HttpError) {
 	srv_proxy := srv.ProxyAddr
 	remote_addr, _, _ := net.SplitHostPort(r.RemoteAddr)
 	real_ip, ok := r.Header["X_HTTP_REAL_IP"]
@@ -158,21 +158,31 @@ func getProxiedClientAddr(srv *Server, r *http.Request) (string, HttpError) {
 	if proxy_request && proxy_server {
 		// Server and client were both proxied
 		if srv_proxy == remote_addr {
-			return real_ip[0], nil
+			if ip := net.ParseIP(real_ip[0]); ip != nil {
+				return ip, nil
+			} else {
+				Log.Printf("Could not parse IP [X_HTTP_REAL_IP]: %q", real_ip[0])
+				return nil, ServerError
+			}
 		} else {
 			Log.Printf("Unauthorized proxied request from %s on behalf of %v", remote_addr, real_ip[0])
-			return "", HttpErrorf(http.StatusBadRequest, "Invalid proxy address")
+			return nil, HttpErrorf(http.StatusBadRequest, "Invalid proxy address")
 		}
 	} else if proxy_request {
 		// Client was proxied but the server wasn't
 		Log.Printf("Unexpected proxied request from %s on behalf of %v", remote_addr, real_ip[0])
-		return "", HttpErrorf(http.StatusBadRequest, "Invalid proxy address")
+		return nil, HttpErrorf(http.StatusBadRequest, "Invalid proxy address")
 	} else if proxy_server {
 		// Server was proxied, but the client wasn't
 		Log.Printf("Unexpected non-proxied request from %s", remote_addr)
-		return "", HttpErrorf(http.StatusBadRequest, "Invalid proxy address")
+		return nil, HttpErrorf(http.StatusBadRequest, "Invalid proxy address")
 	} else {
 		// Neither the server nor the client were proxied.
-		return remote_addr, nil
+		if ip := net.ParseIP(remote_addr); ip != nil {
+			return ip, nil
+		} else {
+			Log.Printf("Could not parse IP [request.RemoteAddr]: %q", real_ip[0])
+			return nil, ServerError
+		}
 	}
 }

--- a/src/api/utils_test.go
+++ b/src/api/utils_test.go
@@ -84,7 +84,12 @@ func TestGetsProxiedAddr(t *testing.T) {
 			r.Header.Set("X_HTTP_REAL_IP", header_addr)
 		}
 		srv := &Server{AtcApiOptions: AtcApiOptions{ProxyAddr: server_addr}}
-		return getProxiedClientAddr(srv, r)
+		addr, err := getProxiedClientAddr(srv, r)
+		if addr != nil {
+			return addr.String(), err
+		} else {
+			return "", err
+		}
 	}
 
 	// Neither the server nor the client are proxied.

--- a/src/daemon/db_test.go
+++ b/src/daemon/db_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"net"
 	"testing"
 	"time"
 
@@ -16,6 +17,9 @@ var (
 		Up:   nil,
 		Down: &atc_thrift.LinkShaping{},
 	}
+
+	IP1 = net.IPv4(1, 2, 3, 4)
+	IP2 = net.IPv4(2, 3, 4, 5)
 )
 
 func TestDBCreatesSchema(t *testing.T) {
@@ -151,15 +155,15 @@ func TestDBInsertsMember(t *testing.T) {
 	if group, err = db.updateGroup(DbGroup{tc: FakeShaping1}); err != nil {
 		t.Fatal(err)
 	}
-	if member, err = db.updateMember(DbMember{"1.2.3.4", group.id}); err != nil {
+	if member, err = db.updateMember(DbMember{IP1, group.id}); err != nil {
 		t.Fatal(err)
 	}
 
 	if member.group_id != group.id {
 		t.Fatalf("Wrong group id: %d != %d", group.id, member.group_id)
 	}
-	if member.addr != "1.2.3.4" {
-		t.Fatalf(`Wrong member address: "1.2.3.4" != %q`, member.addr)
+	if member.addr.String() != IP1.String() {
+		t.Fatalf(`Wrong member address: %q != %q`, IP1, member.addr)
 	}
 }
 
@@ -177,19 +181,19 @@ func TestDBGetsMember(t *testing.T) {
 	if group, err = db.updateGroup(DbGroup{tc: FakeShaping1}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err = db.updateMember(DbMember{"1.2.3.4", group.id}); err != nil {
+	if _, err = db.updateMember(DbMember{IP1, group.id}); err != nil {
 		t.Fatal(err)
 	}
 
-	if member, err = db.getMember("1.2.3.4"); err != nil {
+	if member, err = db.getMember(IP1); err != nil {
 		t.Fatal(err)
 	}
 
 	if member.group_id != group.id {
 		t.Fatalf("Wrong group id: %d != %d", group.id, member.group_id)
 	}
-	if member.addr != "1.2.3.4" {
-		t.Fatalf(`Wrong member address: "1.2.3.4" != %q`, member.addr)
+	if member.addr.String() != IP1.String() {
+		t.Fatalf(`Wrong member address: %q != %q`, IP1, member.addr)
 	}
 }
 
@@ -202,15 +206,15 @@ func TestDBGetsMembersForGroup(t *testing.T) {
 
 	var (
 		group   *DbGroup
-		members []string
+		members []net.IP
 	)
 	if group, err = db.updateGroup(DbGroup{tc: FakeShaping1}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err = db.updateMember(DbMember{"1.2.3.4", group.id}); err != nil {
+	if _, err = db.updateMember(DbMember{IP1, group.id}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err = db.updateMember(DbMember{"2.3.4.5", group.id}); err != nil {
+	if _, err = db.updateMember(DbMember{IP2, group.id}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -236,7 +240,7 @@ func TestDBCleansEmptyGroups(t *testing.T) {
 	if group, err = db.updateGroup(DbGroup{secret: "asdf"}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err = db.updateMember(DbMember{"1.2.3.4", group.id}); err != nil {
+	if _, err = db.updateMember(DbMember{IP1, group.id}); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Cleaned up some error checking and replaced a lot of places where addresses were represented as `string` with `net.IP`
