### PR TITLE
prepare for CIDR addresses

### DIFF
--- a/src/daemon/engine.go
+++ b/src/daemon/engine.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"fmt"
-	"net"
 
 	"github.com/facebook/augmented-traffic-control/src/atc_thrift"
 	"github.com/facebook/augmented-traffic-control/src/shaping"
@@ -51,25 +50,25 @@ func (eng *ShapingEngine) GetPlatform() atc_thrift.PlatformType {
 	return eng.shaper.GetPlatform()
 }
 
-func (eng *ShapingEngine) CreateGroup(id int64, member net.IP) error {
-	if err := eng.shaper.CreateGroup(id, member); err != nil {
+func (eng *ShapingEngine) CreateGroup(id int64, target shaping.Target) error {
+	if err := eng.shaper.CreateGroup(id, target); err != nil {
 		return err
 	}
-	return eng.runHooks(GROUP_JOIN, fmt.Sprintf("%d", id), member.String())
+	return eng.runHooks(GROUP_JOIN, fmt.Sprintf("%d", id), target.String())
 }
 
-func (eng *ShapingEngine) JoinGroup(id int64, member net.IP) error {
-	if err := eng.shaper.JoinGroup(id, member); err != nil {
+func (eng *ShapingEngine) JoinGroup(id int64, target shaping.Target) error {
+	if err := eng.shaper.JoinGroup(id, target); err != nil {
 		return err
 	}
-	return eng.runHooks(GROUP_JOIN, fmt.Sprintf("%d", id), member.String())
+	return eng.runHooks(GROUP_JOIN, fmt.Sprintf("%d", id), target.String())
 }
 
-func (eng *ShapingEngine) LeaveGroup(id int64, member net.IP) error {
-	if err := eng.shaper.LeaveGroup(id, member); err != nil {
+func (eng *ShapingEngine) LeaveGroup(id int64, target shaping.Target) error {
+	if err := eng.shaper.LeaveGroup(id, target); err != nil {
 		return err
 	}
-	return eng.runHooks(GROUP_LEAVE, fmt.Sprintf("%d", id), member.String())
+	return eng.runHooks(GROUP_LEAVE, fmt.Sprintf("%d", id), target.String())
 }
 
 func (eng *ShapingEngine) DeleteGroup(id int64) error {

--- a/src/iptables/chains.go
+++ b/src/iptables/chains.go
@@ -1,0 +1,66 @@
+// +build linux
+
+package iptables
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Chain struct {
+	Name  string
+	table *Table
+}
+
+func (c *Chain) Append(r Rule) error {
+	f, err := r.cmdFormat()
+	if err != nil {
+		return fmt.Errorf("Could not append to %s chain: %v", c.Name, err)
+	}
+	if _, err := c.table.cmd(prepend([]string{"-A", c.Name}, f)...); err != nil {
+		return fmt.Errorf("Could not append to %s chain: %v", c.Name, err)
+	} else {
+		return nil
+	}
+}
+
+func (c *Chain) Flush() error {
+	if _, err := c.table.cmd("-F", c.Name); err != nil {
+		return fmt.Errorf("Could not flush %s chain: %v", c.Name, err)
+	} else {
+		return nil
+	}
+}
+
+func (c *Chain) Delete(r Rule) error {
+	f, err := r.cmdFormat()
+	if err != nil {
+		return fmt.Errorf("Could not delete from %s chain: %v", c.Name, err)
+	}
+	if _, err := c.table.cmd(prepend([]string{"-D", c.Name}, f)...); err != nil {
+		return fmt.Errorf("Could not delete from %s chain: %v", c.Name, err)
+	} else {
+		return nil
+	}
+}
+
+func (c *Chain) GetRules(target Target) ([]Rule, error) {
+	out, err := c.table.cmd("-nvL", c.Name, "--line-numbers")
+	if err != nil {
+		return nil, err
+	}
+
+	rules := make([]Rule, 0, 2)
+	for i, l := range strings.Split(out.String(), "\n") {
+		if i < 2 || strings.TrimSpace(l) == "" {
+			continue // skip the headers and empty lines
+		}
+
+		if rule, err := parseRule(target, l); err != nil {
+			return nil, err
+		} else if rule != nil {
+			rules = append(rules, *rule)
+		}
+	}
+	return rules, nil
+}

--- a/src/iptables/iptables.go
+++ b/src/iptables/iptables.go
@@ -1,0 +1,45 @@
+// +build linux
+
+package iptables
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const (
+	default_table = "filter"
+)
+
+type IPTables struct {
+	Command string
+}
+
+func New(command string) *IPTables {
+	return &IPTables{command}
+}
+
+func (t *IPTables) Table(name string) *Table {
+	return &Table{name, t}
+}
+
+func (t *IPTables) Chain(name string) *Chain {
+	return t.Table(default_table).Chain(name)
+}
+
+func (t *IPTables) cmd(argv ...string) (*bytes.Buffer, error) {
+	fmt.Println("Command:", t.Command, strings.Join(argv, " "))
+	cmd := exec.Command(t.Command, argv...)
+	var (
+		out_err = &bytes.Buffer{}
+		out     = &bytes.Buffer{}
+	)
+	cmd.Stdout = out
+	cmd.Stderr = out_err
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("Could not run %s: %v\n%v", t.Command, err, out_err)
+	}
+	return out, nil
+}

--- a/src/iptables/iptables.go
+++ b/src/iptables/iptables.go
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
-	"strings"
 )
 
 const (
@@ -30,7 +29,6 @@ func (t *IPTables) Chain(name string) *Chain {
 }
 
 func (t *IPTables) cmd(argv ...string) (*bytes.Buffer, error) {
-	fmt.Println("Command:", t.Command, strings.Join(argv, " "))
 	cmd := exec.Command(t.Command, argv...)
 	var (
 		out_err = &bytes.Buffer{}

--- a/src/iptables/rules.go
+++ b/src/iptables/rules.go
@@ -1,0 +1,109 @@
+// +build linux
+
+package iptables
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Rule struct {
+	Index       int
+	Pkts        int64
+	Bytes       int64
+	Target      string
+	Proto       string
+	Opts        string
+	In          string
+	Out         string
+	Source      Target
+	Destination Target
+	Args        []string
+}
+
+func (r Rule) cmdFormat() ([]string, error) {
+	if r.Target == "" {
+		return nil, fmt.Errorf("Rule has no target.")
+	}
+	s := make([]string, 0, 5)
+	// Only jump is implemented. -g is not used.
+	s = append(s, "-j", r.Target)
+	if r.Source != nil {
+		s = append(s, "-s", r.Source.String())
+	}
+	if r.Destination != nil {
+		s = append(s, "-d", r.Destination.String())
+	}
+	if r.In != "" {
+		s = append(s, "-i", r.In)
+	}
+	if r.Out != "" {
+		s = append(s, "-i", r.Out)
+	}
+	if r.Proto != "" {
+		s = append(s, "-p", r.Proto)
+	}
+	s = append(s, r.Args...)
+	return s, nil
+}
+
+func (r Rule) SetMark(mark int64) Rule {
+	n := r
+	n.Target = "MARK"
+	n.Args = append(r.Args, "--set-xmark", fmt.Sprintf("0x%x", mark))
+	return n
+}
+
+func parseRule(target Target, line string) (*Rule, error) {
+	line_tokens := make([]string, 0, 10)
+	for _, r := range strings.Split(line, " ") {
+		if r != "" {
+			line_tokens = append(line_tokens, r)
+		}
+	}
+
+	m := &Rule{
+		Index:       0,
+		Pkts:        0,
+		Bytes:       0,
+		Target:      line_tokens[3],
+		Proto:       line_tokens[4],
+		Opts:        line_tokens[5],
+		In:          line_tokens[6],
+		Out:         line_tokens[7],
+		Source:      nil,
+		Destination: nil,
+		Args:        []string{},
+	}
+	var err error
+	m.Source, err = parseTarget(line_tokens[8])
+	if err != nil {
+		return nil, err
+	}
+	m.Destination, err = parseTarget(line_tokens[9])
+	if err != nil {
+		return nil, err
+	}
+
+	if target != nil && m.Source.String() != target.String() && m.Destination.String() != target.String() {
+		return nil, nil
+	}
+
+	m.Index, err = strconv.Atoi(line_tokens[0])
+	if err != nil {
+		return nil, fmt.Errorf("Could not parse line number: %v", err)
+	}
+	m.Pkts, err = strconv.ParseInt(line_tokens[1], 0, 64)
+	if err != nil {
+		return nil, fmt.Errorf("Could not parse packet count: %v", err)
+	}
+	m.Bytes, err = strconv.ParseInt(line_tokens[2], 0, 64)
+	if err != nil {
+		return nil, fmt.Errorf("Could not parse byte count: %v", err)
+	}
+	if len(line_tokens) > 10 {
+		m.Args = line_tokens[10:]
+	}
+	return m, nil
+}

--- a/src/iptables/table.go
+++ b/src/iptables/table.go
@@ -1,0 +1,53 @@
+// +build linux
+
+package iptables
+
+import (
+	"bytes"
+	"strings"
+)
+
+type Table struct {
+	Name string
+	ipt  *IPTables
+}
+
+func (t *Table) Chain(name string) *Chain {
+	return &Chain{name, t}
+}
+
+func (t *Table) GetRules(target Target) ([]Rule, error) {
+	out, err := t.cmd("-nvL", "--line-numbers")
+	if err != nil {
+		return nil, err
+	}
+
+	rules := make([]Rule, 0, 2)
+	for i, l := range strings.Split(out.String(), "\n") {
+		if i < 2 || strings.TrimSpace(l) == "" {
+			continue // skip the headers and empty lines
+		}
+
+		if rule, err := parseRule(target, l); err != nil {
+			return nil, err
+		} else if rule != nil {
+			rules = append(rules, *rule)
+		}
+	}
+	return rules, nil
+}
+
+func (t *Table) cmd(args ...string) (*bytes.Buffer, error) {
+	return t.ipt.cmd(prepend([]string{"-t", t.Name}, args)...)
+}
+
+func prepend(before, after []string) []string {
+	all := make([]string, 0, len(before)+len(after))
+	for _, i := range before {
+		all = append(all, i)
+	}
+	for _, i := range after {
+		all = append(all, i)
+	}
+	return all
+}

--- a/src/iptables/targets.go
+++ b/src/iptables/targets.go
@@ -34,7 +34,14 @@ func (t CIDRTarget) String() string {
 
 func parseTarget(s string) (Target, error) {
 	if ip := net.ParseIP(s); ip != nil {
-		return IPTarget(ip), nil
+		// ParseIP returns IPv4 addresses as 0::ff:ff:w:x:y:z for some reason
+		// this causes issues with unit tests since they compare byte arrays
+		// work around by truncating when the address is a v4 address.
+		if v4 := ip.To4(); v4 == nil {
+			return IPTarget(ip), nil
+		} else {
+			return IPTarget(v4), nil
+		}
 	}
 	if _, net, err := net.ParseCIDR(s); err == nil {
 		return &CIDRTarget{net}, nil

--- a/src/iptables/targets.go
+++ b/src/iptables/targets.go
@@ -1,0 +1,44 @@
+package iptables
+
+import (
+	"fmt"
+	"net"
+)
+
+type Target interface {
+	V6() bool
+	String() string
+}
+
+type IPTarget net.IP
+
+func (t IPTarget) V6() bool {
+	return net.IP(t).To4() == nil
+}
+
+func (t IPTarget) String() string {
+	return net.IP(t).String()
+}
+
+type CIDRTarget struct {
+	Net *net.IPNet
+}
+
+func (t CIDRTarget) V6() bool {
+	return t.Net.IP.To4() == nil
+}
+
+func (t CIDRTarget) String() string {
+	return t.Net.String()
+}
+
+func parseTarget(s string) (Target, error) {
+	if ip := net.ParseIP(s); ip != nil {
+		return IPTarget(ip), nil
+	}
+	if _, net, err := net.ParseCIDR(s); err == nil {
+		return &CIDRTarget{net}, nil
+	} else {
+		return nil, fmt.Errorf("Could not parse iptables target: %q", s)
+	}
+}

--- a/src/shaping/shaping.go
+++ b/src/shaping/shaping.go
@@ -5,9 +5,8 @@ shapers must conform. It also contains platform-specific shapers.
 package shaping
 
 import (
-	"net"
-
 	"github.com/facebook/augmented-traffic-control/src/atc_thrift"
+	"github.com/facebook/augmented-traffic-control/src/iptables"
 	. "github.com/facebook/augmented-traffic-control/src/log"
 )
 
@@ -16,6 +15,8 @@ var Log *LogMux
 func init() {
 	Log = NewMux(Syslog(), Stdlog())
 }
+
+type Target iptables.Target
 
 type Shaper interface {
 	// Get the platform type for this shaper.
@@ -27,13 +28,13 @@ type Shaper interface {
 	Initialize() error
 
 	// Create a new group with the given id number and initial member.
-	CreateGroup(id int64, member net.IP) error
+	CreateGroup(id int64, member Target) error
 
 	// Add the provided member to the given group.
-	JoinGroup(id int64, member net.IP) error
+	JoinGroup(id int64, member Target) error
 
 	// Remove the provided member from the given group.
-	LeaveGroup(id int64, member net.IP) error
+	LeaveGroup(id int64, member Target) error
 
 	// Delete a group. The group is assumed to be empty *before* DeleteGroup
 	// is called.
@@ -60,9 +61,9 @@ func (FakeShaper) GetPlatform() atc_thrift.PlatformType {
 }
 
 func (FakeShaper) Initialize() error                                 { return nil }
-func (FakeShaper) CreateGroup(int64, net.IP) error                   { return nil }
-func (FakeShaper) JoinGroup(int64, net.IP) error                     { return nil }
-func (FakeShaper) LeaveGroup(int64, net.IP) error                    { return nil }
+func (FakeShaper) CreateGroup(int64, Target) error                   { return nil }
+func (FakeShaper) JoinGroup(int64, Target) error                     { return nil }
+func (FakeShaper) LeaveGroup(int64, Target) error                    { return nil }
 func (FakeShaper) DeleteGroup(int64) error                           { return nil }
 func (FakeShaper) Shape(id int64, shaping *atc_thrift.Shaping) error { return nil }
 func (FakeShaper) Unshape(int64) error                               { return nil }


### PR DESCRIPTION
TLDR; lots of cleanup to make code in `src/shaping` ready for CIDR addresses.
## Abstracted out `net.IP` usage in `src/shaping` to allow for CIDR addresses in the future.

The idea here is `Shaper`s will accept values of type `Target` rather than `net.IP`. An implementation of these target types can be found in `src/iptables/targets.go`. Clients are responsible for converting `net.IP` or `net.IPNet` values into the appropriate Target type before passing them to the `Shaper`.
Currently `atcd` only allows `IPTarget` values.

I'm not quite sure what effect the inclusion of CIDR address will do to the thrift spec, but this approach to the `Shaper` should give us the freedom to make changes to the thrift spec easily.
## Added `src/iptables` which has simple general-purpose iptables bindings.

The code is self-contained in `src/iptables` and has no dependencies outside the go standard library.

There's a lot of stuff here, so if you want we can discuss this in person to go over fine details before landing.
