### PR TITLE
Allow shaping on CIDR addresses

### DIFF
--- a/src/atc/main.go
+++ b/src/atc/main.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"net"
 	"os"
 	"strings"
 
 	"github.com/facebook/augmented-traffic-control/src/api"
+
 	"github.com/facebook/augmented-traffic-control/src/atc_thrift"
 	atclog "github.com/facebook/augmented-traffic-control/src/log"
 	"gopkg.in/alecthomas/kingpin.v2"
@@ -42,8 +42,8 @@ func main() {
 
 		// Duplicate flags/args
 		id      int64
-		members []net.IP
-		member  net.IP
+		members []string
+		member  string
 	)
 
 	kingpin.Command("info", "Prints info about the ATC shaping")
@@ -52,9 +52,9 @@ func main() {
 
 	groupAdd := kingpin.Command("create", "create a group")
 	if defMember != "" {
-		groupAdd.Arg("member", "IP address of the member (env:ATC_MEMBER)").Default(defMember).IPVar(&member)
+		groupAdd.Arg("member", "IP address of the member (env:ATC_MEMBER)").Default(defMember).StringVar(&member)
 	} else {
-		groupAdd.Arg("member", "IP address of the member (env:ATC_MEMBER)").Required().IPVar(&member)
+		groupAdd.Arg("member", "IP address of the member (env:ATC_MEMBER)").Required().StringVar(&member)
 	}
 
 	groupShow := kingpin.Command("show", "show info about a group")
@@ -63,17 +63,17 @@ func main() {
 	groupJoin := kingpin.Command("join", "leave a group")
 	groupJoin.Arg("id", "id of the group").Required().Int64Var(&id)
 	if defMember != "" {
-		groupJoin.Arg("members", "IP address of the members (env:ATC_MEMBER)").Default(defMember).IPListVar(&members)
+		groupJoin.Arg("members", "IP address of the members (env:ATC_MEMBER)").Default(defMember).StringsVar(&members)
 	} else {
-		groupJoin.Arg("members", "IP address of the members (env:ATC_MEMBER)").Required().IPListVar(&members)
+		groupJoin.Arg("members", "IP address of the members (env:ATC_MEMBER)").Required().StringsVar(&members)
 	}
 
 	groupLeave := kingpin.Command("leave", "leave a group")
 	groupLeave.Arg("id", "id of the group").Required().Int64Var(&id)
 	if defMember != "" {
-		groupLeave.Arg("members", "IP address of the members (env:ATC_MEMBER)").Default(defMember).IPListVar(&members)
+		groupLeave.Arg("members", "IP address of the members (env:ATC_MEMBER)").Default(defMember).StringsVar(&members)
 	} else {
-		groupLeave.Arg("members", "IP address of the members (env:ATC_MEMBER)").Required().IPListVar(&members)
+		groupLeave.Arg("members", "IP address of the members (env:ATC_MEMBER)").Required().StringsVar(&members)
 	}
 
 	groupToken := kingpin.Command("token", "get a token")
@@ -167,8 +167,8 @@ func ServerInfo() {
 	fmt.Printf("atcd %v %v\n", info.Version, info.Platform)
 }
 
-func GroupAdd(member net.IP) {
-	grp, err := atcd.CreateGroup(member.String())
+func GroupAdd(member string) {
+	grp, err := atcd.CreateGroup(member)
 	if err != nil {
 		Log.Fatalln(err)
 	}
@@ -194,8 +194,8 @@ func GroupList() {
 	}
 }
 
-func GroupJoin(id int64, member net.IP, token string) {
-	if err := atcd.JoinGroup(id, member.String(), token); err != nil {
+func GroupJoin(id int64, member string, token string) {
+	if err := atcd.JoinGroup(id, member, token); err != nil {
 		Log.Fatalf("Could not join group: %v", err)
 	}
 	grp, err := atcd.GetGroup(id)
@@ -205,9 +205,9 @@ func GroupJoin(id int64, member net.IP, token string) {
 	printShortGroup(grp)
 }
 
-func GroupLeave(id int64, member net.IP, token string) {
-	if err := atcd.LeaveGroup(id, member.String(), token); err != nil {
-		Log.Fatalln(err)
+func GroupLeave(id int64, member string, token string) {
+	if err := atcd.LeaveGroup(id, member, token); err != nil {
+		Log.Fatalf("Could not leave group: %v", err)
 	}
 }
 

--- a/src/daemon/atcd.go
+++ b/src/daemon/atcd.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"fmt"
-	"net"
 
 	"github.com/facebook/augmented-traffic-control/src/atc_thrift"
 	"github.com/facebook/augmented-traffic-control/src/iptables"
@@ -102,11 +101,10 @@ func (atcd *Atcd) ListGroups() ([]*atc_thrift.ShapingGroup, error) {
 }
 
 func (atcd *Atcd) CreateGroup(member string) (*atc_thrift.ShapingGroup, error) {
-	ip := net.ParseIP(member)
-	if ip == nil {
-		return nil, fmt.Errorf("Malformed IP address: %q", member)
+	tgt, err := iptables.ParseTarget(member)
+	if err != nil {
+		return nil, err
 	}
-	tgt := iptables.IPTarget(ip)
 	grp := &atc_thrift.ShapingGroup{
 		Members: []string{member},
 		Shaping: nil,
@@ -153,11 +151,10 @@ func (atcd *Atcd) GetGroup(id int64) (*atc_thrift.ShapingGroup, error) {
 }
 
 func (atcd *Atcd) GetGroupWith(addr string) (*atc_thrift.ShapingGroup, error) {
-	ip := net.ParseIP(addr)
-	if ip == nil {
-		return nil, fmt.Errorf("Malformed IP address: %q", addr)
+	tgt, err := iptables.ParseTarget(addr)
+	if err != nil {
+		return nil, err
 	}
-	tgt := iptables.IPTarget(ip)
 	member, err := atcd.db.getMember(tgt)
 	if err != nil {
 		return nil, err
@@ -177,11 +174,10 @@ func (atcd *Atcd) GetGroupToken(id int64) (string, error) {
 }
 
 func (atcd *Atcd) JoinGroup(id int64, to_add, token string) error {
-	ip := net.ParseIP(to_add)
-	if ip == nil {
-		return fmt.Errorf("Malformed IP address: %q", to_add)
+	tgt, err := iptables.ParseTarget(to_add)
+	if err != nil {
+		return err
 	}
-	tgt := iptables.IPTarget(ip)
 	group, err := atcd.db.getGroup(id)
 	if err != nil {
 		return err
@@ -203,11 +199,10 @@ func (atcd *Atcd) JoinGroup(id int64, to_add, token string) error {
 }
 
 func (atcd *Atcd) LeaveGroup(id int64, to_remove, token string) error {
-	ip := net.ParseIP(to_remove)
-	if ip == nil {
-		return fmt.Errorf("Malformed IP address: %q", to_remove)
+	tgt, err := iptables.ParseTarget(to_remove)
+	if err != nil {
+		return err
 	}
-	tgt := iptables.IPTarget(ip)
 	member, err := atcd.db.getMember(tgt)
 	if err != nil {
 		return err

--- a/src/daemon/atcd.go
+++ b/src/daemon/atcd.go
@@ -41,10 +41,10 @@ func ReshapeFromDb(shaper *ShapingEngine, db *DbRunner) error {
 		for _, member := range members {
 			var err error
 			if first {
-				err = shaper.CreateGroup(group.id, iptables.IPTarget(member))
+				err = shaper.CreateGroup(group.id, member)
 				first = false
 			} else {
-				err = shaper.JoinGroup(group.id, iptables.IPTarget(member))
+				err = shaper.JoinGroup(group.id, member)
 			}
 			if err != nil {
 				return err
@@ -95,7 +95,7 @@ func (atcd *Atcd) ListGroups() ([]*atc_thrift.ShapingGroup, error) {
 		results = append(results, &atc_thrift.ShapingGroup{
 			ID:      grp.id,
 			Shaping: grp.tc,
-			Members: IPsToStrings(members),
+			Members: TargetsToStrings(members),
 		})
 	}
 	return results, nil
@@ -106,6 +106,7 @@ func (atcd *Atcd) CreateGroup(member string) (*atc_thrift.ShapingGroup, error) {
 	if ip == nil {
 		return nil, fmt.Errorf("Malformed IP address: %q", member)
 	}
+	tgt := iptables.IPTarget(ip)
 	grp := &atc_thrift.ShapingGroup{
 		Members: []string{member},
 		Shaping: nil,
@@ -120,11 +121,11 @@ func (atcd *Atcd) CreateGroup(member string) (*atc_thrift.ShapingGroup, error) {
 	// Have to create group in database before creating the shaper since
 	// the database gives us the unique ID of the group, which the shaper
 	// needs for the mark.
-	if err := atcd.shaper.CreateGroup(dbgrp.id, iptables.IPTarget(ip)); err != nil {
+	if err := atcd.shaper.CreateGroup(dbgrp.id, tgt); err != nil {
 		return nil, err
 	}
 	dbmem := <-atcd.db.UpdateMember(DbMember{
-		addr:     ip,
+		addr:     tgt,
 		group_id: dbgrp.id,
 	})
 	if dbmem == nil {
@@ -145,7 +146,7 @@ func (atcd *Atcd) GetGroup(id int64) (*atc_thrift.ShapingGroup, error) {
 	}
 	grp := &atc_thrift.ShapingGroup{
 		ID:      id,
-		Members: IPsToStrings(members),
+		Members: TargetsToStrings(members),
 		Shaping: group.tc,
 	}
 	return grp, nil
@@ -156,7 +157,8 @@ func (atcd *Atcd) GetGroupWith(addr string) (*atc_thrift.ShapingGroup, error) {
 	if ip == nil {
 		return nil, fmt.Errorf("Malformed IP address: %q", addr)
 	}
-	member, err := atcd.db.getMember(ip)
+	tgt := iptables.IPTarget(ip)
+	member, err := atcd.db.getMember(tgt)
 	if err != nil {
 		return nil, err
 	}
@@ -179,6 +181,7 @@ func (atcd *Atcd) JoinGroup(id int64, to_add, token string) error {
 	if ip == nil {
 		return fmt.Errorf("Malformed IP address: %q", to_add)
 	}
+	tgt := iptables.IPTarget(ip)
 	group, err := atcd.db.getGroup(id)
 	if err != nil {
 		return err
@@ -189,11 +192,11 @@ func (atcd *Atcd) JoinGroup(id int64, to_add, token string) error {
 	if !atcd.verify(group, token) {
 		return fmt.Errorf("Unauthorized")
 	}
-	if err := atcd.shaper.JoinGroup(id, iptables.IPTarget(ip)); err != nil {
+	if err := atcd.shaper.JoinGroup(id, tgt); err != nil {
 		return err
 	}
 	_, err = atcd.db.updateMember(DbMember{
-		addr:     ip,
+		addr:     tgt,
 		group_id: group.id,
 	})
 	return err
@@ -204,7 +207,8 @@ func (atcd *Atcd) LeaveGroup(id int64, to_remove, token string) error {
 	if ip == nil {
 		return fmt.Errorf("Malformed IP address: %q", to_remove)
 	}
-	member, err := atcd.db.getMember(ip)
+	tgt := iptables.IPTarget(ip)
+	member, err := atcd.db.getMember(tgt)
 	if err != nil {
 		return err
 	}
@@ -218,12 +222,12 @@ func (atcd *Atcd) LeaveGroup(id int64, to_remove, token string) error {
 	if !atcd.verify(group, token) {
 		return fmt.Errorf("Unauthorized")
 	}
-	if err := atcd.shaper.LeaveGroup(id, iptables.IPTarget(ip)); err != nil {
+	if err := atcd.shaper.LeaveGroup(id, tgt); err != nil {
 		return err
 	}
 	// FIXME: clean shaper's group too!
 	defer atcd.db.Cleanup()
-	return atcd.db.deleteMember(ip)
+	return atcd.db.deleteMember(tgt)
 }
 
 func (atcd *Atcd) ShapeGroup(id int64, settings *atc_thrift.Shaping, token string) (*atc_thrift.Shaping, error) {
@@ -294,7 +298,7 @@ func makeSecret() string {
 	return uuid.New()
 }
 
-func IPsToStrings(ips []net.IP) []string {
+func TargetsToStrings(ips []iptables.Target) []string {
 	s := make([]string, len(ips))
 	for i, ip := range ips {
 		s[i] = ip.String()

--- a/src/iptables/rules.go
+++ b/src/iptables/rules.go
@@ -84,7 +84,7 @@ func parseRule(target Target, line string) (*Rule, error) {
 	// as an IP
 	// all positions are 0-indexed, fyi
 
-	_, err := parseTarget(line_tokens[7])
+	_, err := ParseTarget(line_tokens[7])
 	// optPos is the position of the options field, or the position where it would
 	// be relative to fields after it.
 	// This way we can parse fields by a constant offset after the option position.
@@ -99,11 +99,11 @@ func parseRule(target Target, line string) (*Rule, error) {
 	m.In = line_tokens[optPos+1]
 	m.Out = line_tokens[optPos+2]
 
-	m.Source, err = parseTarget(line_tokens[optPos+3])
+	m.Source, err = ParseTarget(line_tokens[optPos+3])
 	if err != nil {
 		return nil, err
 	}
-	m.Destination, err = parseTarget(line_tokens[optPos+4])
+	m.Destination, err = ParseTarget(line_tokens[optPos+4])
 	if err != nil {
 		return nil, err
 	}

--- a/src/iptables/targets.go
+++ b/src/iptables/targets.go
@@ -6,7 +6,11 @@ import (
 )
 
 type Target interface {
+	// Returns true if the target is an IPv6 target.
 	V6() bool
+
+	// Returns a string representation of the target that is suitable for
+	// passing to iptables binaries.
 	String() string
 }
 
@@ -32,7 +36,7 @@ func (t CIDRTarget) String() string {
 	return t.Net.String()
 }
 
-func parseTarget(s string) (Target, error) {
+func ParseTarget(s string) (Target, error) {
 	if ip := net.ParseIP(s); ip != nil {
 		// ParseIP returns IPv4 addresses as 0::ff:ff:w:x:y:z for some reason
 		// this causes issues with unit tests since they compare byte arrays
@@ -46,6 +50,6 @@ func parseTarget(s string) (Target, error) {
 	if _, net, err := net.ParseCIDR(s); err == nil {
 		return &CIDRTarget{net}, nil
 	} else {
-		return nil, fmt.Errorf("Could not parse iptables target: %q", s)
+		return nil, fmt.Errorf("Could not parse target: %q", s)
 	}
 }


### PR DESCRIPTION
This PR allows `atcd` to shape on CIDR addresses.
This was surprisingly easy since `atcd` was using `iptables.Target` in most places already.

Each commit should build on its own, and is pretty simple:
- 8eb47843689e2d7996402b8c36bbb4a25a8b000c exposes the `ParseTarget` function from `iptables`, since we'll need to parse targets in `atcd` if we allow more than one type.
- 341b71f8e9935d2e0368746f5316ef1dc1c00716 modifies the `DbRunner` type in `atcd` to allow passing in `Target` types instead of `net.IP` types.
- 8e6d5eb271c91adc90a830ad6eddd83a3a296114 makes `atcd` parse targets correctly instead of assuming they're IPs.
- 11bce352c60d75beb7469539db2066679c40d7c7 modifies the command-line client to allow CIDR addresses.

This PR is probably easier to digest if it's read one commit at a time.

[Tests](https://gist.github.com/zfjagann/1eb71c827551215e99f9)
