### PR TITLE
Use URL for thrift conn info

### DIFF
--- a/src/api/atc_connector.go
+++ b/src/api/atc_connector.go
@@ -2,7 +2,7 @@ package api
 
 import (
 	"fmt"
-	"net"
+	"net/url"
 
 	"git.apache.org/thrift.git/lib/go/thrift"
 	"github.com/facebook/augmented-traffic-control/src/atc_thrift"
@@ -29,21 +29,19 @@ type AtcdCloser interface {
 
 type AtcdConn struct {
 	*atc_thrift.AtcdClient
-	xport        thrift.TTransport
-	thrift_addr  *net.TCPAddr
-	thrift_proto string
+	xport      thrift.TTransport
+	thrift_url *url.URL
 }
 
-func NewAtcdConn(thrift_addr *net.TCPAddr, thrift_proto string) *AtcdConn {
+func NewAtcdConn(thrift_url *url.URL) *AtcdConn {
 	return &AtcdConn{
-		thrift_addr:  thrift_addr,
-		thrift_proto: thrift_proto,
+		thrift_url: thrift_url,
 	}
 }
 
 func (atcd *AtcdConn) Open() error {
 	var err error
-	atcd.xport, err = thrift.NewTSocket(atcd.thrift_addr.String())
+	atcd.xport, err = thrift.NewTSocket(atcd.thrift_url.Host)
 	if err != nil {
 		return err
 	}
@@ -51,7 +49,7 @@ func (atcd *AtcdConn) Open() error {
 		return err
 	}
 
-	pfactory, err := getThriftProtocol(atcd.thrift_proto)
+	pfactory, err := getThriftProtocol(atcd.thrift_url.Scheme)
 	if err != nil {
 		return err
 	}

--- a/src/api/server.go
+++ b/src/api/server.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net"
 	"net/http"
+	"net/url"
 	"strconv"
 	"time"
 
@@ -17,8 +18,8 @@ var (
 )
 
 type AtcApiOptions struct {
-	Addr, ThriftAddr *net.TCPAddr
-	ThriftProto      string
+	Addr             *net.TCPAddr
+	ThriftUrl        *url.URL
 	DBDriver, DBConn string
 	V4, V6           string
 	ProxyAddr        string
@@ -81,7 +82,7 @@ func (srv *Server) GetAtcd() (AtcdCloser, HttpError) {
 	if srv.Atcd != nil {
 		return srv.Atcd, nil
 	}
-	atcd := NewAtcdConn(srv.ThriftAddr, srv.ThriftProto)
+	atcd := NewAtcdConn(srv.ThriftUrl)
 	if err := atcd.Open(); err != nil {
 		return nil, HttpErrorf(502, "Could not connect to atcd: %v", err)
 	}

--- a/src/atc/main.go
+++ b/src/atc/main.go
@@ -34,8 +34,8 @@ func GetEnv(name, def string) string {
 }
 
 func main() {
-	thriftAddr := kingpin.Flag("thrift-addr", "thrift server address (env:ATCD_ADDR)").Short('T').Default("127.0.0.1:9090").Envar("ATCD_ADDR").TCP()
-	thriftProto := kingpin.Flag("thrift-proto", "thrift server protocol (env:ATCD_PROTO)").Short('P').Default("json").Envar("ATCD_PROTO").String()
+	thriftUrl := kingpin.Flag("thrift-addr", "thrift server url in the format 'proto://host:port' (env:ATCD_ADDR)").Short('r').
+		Default("json://127.0.0.1:9090").Envar("ATCD_ADDR").URL()
 
 	var (
 		defMember = GetEnv("ATC_MEMBER", "")
@@ -105,7 +105,7 @@ func main() {
 
 	cmd := kingpin.Parse()
 
-	atcd = api.NewAtcdConn(*thriftAddr, *thriftProto)
+	atcd = api.NewAtcdConn(*thriftUrl)
 	if err := atcd.Open(); err != nil {
 		Log.Fatalln("Could not open connection to atcd:", err)
 	}


### PR DESCRIPTION
```
$ atc_api -4 127.0.0.1
2016/01/15 15:20:59 Connected to atcd socket on json://127.0.0.1:9090
$ atc --help
...
  -r, --thrift-addr=json://127.0.0.1:9090  
              thrift server url in the format 'proto://host:port' (env:ATCD_ADDR)
$ atc -r json://127.0.0.1:9090 info
atcd 2.0-go LINUX
```
