### PR TITLE
Fix shebang for test script.

### DIFF
--- a/utils/test-cleanup.sh
+++ b/utils/test-cleanup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 if [ "$(whoami)" != "root" ] ; then
     sudo "$0"

--- a/utils/test-setup.sh
+++ b/utils/test-setup.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 if [ "$(whoami)" != "root" ] ; then
     sudo "$0" 


### PR DESCRIPTION
system bash is typically under /bin/bash by default, /usr/bin/bash may not be present
