### PR TITLE
[chef] Fix chef run on ubuntu by including apt recipe.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - "2.7"
 install:
     - pip install flake8
+    - pip install pep8
     - pip install atc/atc_thrift/ atc/atcd/ atc/django-atc-api/ atc/django-atc-demo-ui/ atc/django-atc-profile-storage/
     - pip install -r atc/atcd/requirements/requirements-testing.txt
 script:

--- a/atc/django-atc-demo-ui/setup.py
+++ b/atc/django-atc-demo-ui/setup.py
@@ -21,7 +21,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.md')) as readme:
 install_requires = [
     'django-atc-api',
     'django-static-jquery==1.11.1',
-    'django-bootstrap-themes==3.1.2',
+    'django-bootstrap-themes==3.3.6',
 ]
 
 

--- a/chef/atc/Vagrantfile
+++ b/chef/atc/Vagrantfile
@@ -35,7 +35,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             box.berkshelf.enabled = true
             box.vm.provision :chef_solo do |chef|
                 chef.run_list = [
-                    "recipe[python]",
                     "recipe[atc::default]"
                 ]
                 if opts.fetch(:python_from_source, false)

--- a/chef/atc/attributes/default.rb
+++ b/chef/atc/attributes/default.rb
@@ -27,7 +27,7 @@ default['atc']['venv']['atcd']['packages'] = {
 
 # 'pyroute2' => {:action => :upgrade, :version => "0.1.12"},
 default['atc']['venv']['atcui']['packages'] = {
-  'django' => { :version => '1.7' },
+  'django' => { :version => '1.9' },
   'gunicorn' => {},
   "file://#{File.join(src_dir, 'atc/atc_thrift/')}" =>
     { :action => :install, :options => '-e' },

--- a/chef/atc/metadata.rb
+++ b/chef/atc/metadata.rb
@@ -15,6 +15,7 @@ description      'Installs/Configures atc'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.0'
 
+depends 'apt'
 depends 'dhcp', '~> 2.2.2'
 depends 'python'
 depends 'simple_iptables', '~> 0.6.4'

--- a/chef/atc/recipes/_common_system.rb
+++ b/chef/atc/recipes/_common_system.rb
@@ -14,7 +14,11 @@
 case node['platform_family']
 when 'rhel'
   include_recipe 'yum-epel'
+when 'debian'
+  include_recipe 'apt'
 end
+
+include_recipe 'python'
 
 group node['atc']['atcui']['group'] do
   system


### PR DESCRIPTION
This will force an `apt-get update` if cache is too old.
Fixes #279