### PR TITLE
don't autoescape html in the demo UI

### DIFF
--- a/atc/django-atc-demo-ui/atc_demo_ui/templates/atc_demo_ui/base.html
+++ b/atc/django-atc-demo-ui/atc_demo_ui/templates/atc_demo_ui/base.html
@@ -25,10 +25,12 @@
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="{% static 'static_jquery/js/jquery.min.js' %}"></script>
 
+    {% autoescape off %}
     <!-- Bootstrap CSS -->
     {% bootstrap_styles theme='default' type='min.css' %}
     <!-- Bootstrap JS -->
     {% bootstrap_script use_min=True %}
+    {% endautoescape %}
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>


### PR DESCRIPTION
The Demo UI seems broken with django 1.9 because these guys get escaped (< becomes &lt ; etc)

from "view-source":

    <!-- Bootstrap CSS -->
    &lt;link rel=&quot;stylesheet&quot; href=&quot;/static/bootstrap/themes/default/css/bootstrap.min.css&quot; type=&quot;text/css&quot;&gt;
    <!-- Bootstrap JS -->
    &lt;script type=&quot;text/javascript&quot; src=&quot;/static/bootstrap/js/bootstrap.min.js&quot;&gt;&lt;/script&gt;
