### PR TITLE
[atc_profile_storage] convert content to a string as this seems to be

### DIFF
--- a/atc/django-atc-profile-storage/atc_profile_storage/views.py
+++ b/atc/django-atc-profile-storage/atc_profile_storage/views.py
@@ -31,6 +31,7 @@ def profile_list(request):
 
     elif request.method == 'POST':
         data = JSONParser().parse(request)
+        data['content'] = str(data['content'])
         serializer = ProfileSerializer(data=data)
         if serializer.is_valid():
             serializer.save()


### PR DESCRIPTION
needed by drf.
Confirmed that I could load new profiles using
./utils/restore-profiles.sh localhost:8080.
Fixes #287