### PR TITLE
[make] Enable static builds

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -45,6 +45,14 @@ make
 
 This will download all atcd dependencies as well as build it, run tests and install it.
 
+### Making a static build
+
+Golang binary can easily be built sttatically, allowing to copy the binary around without even have to worry about libc. To build ATC statically, set the `STATICBUILD` environment variable to somehting as in:
+
+```
+STATICBUILD=1 make
+```
+
 ## Starting ATC
 
 After you have built ATC, you can run it by running (from within the default workdir):

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,9 @@ PREFIX = /usr/local
 GO = $(shell which go)
 BUILD = $(GO) build
 # for static compilation:
-#BUILD += --ldflags '-extldflags "-static"'
+ifdef STATICBUILD
+	BUILD += --ldflags '-extldflags "-static"'
+endif
 
 TEST = $(GO) test -v
 VET = $(GO) vet


### PR DESCRIPTION
By setting the `STATICBUILD` environment variable when invoking `make`,
build atc golang parts statically.