### PR TITLE
[django] add support for django 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Now, open `atcui/urls.py` and enable routing to the `ATC` apps by adding the rou
 from django.views.generic.base import RedirectView
 from django.conf.urls import include
 
-urlpatterns = patterns('',
+urlpatterns = [
     ...
     # Django ATC API
     url(r'^api/v1/', include('atc_api.urls')),
@@ -94,7 +94,7 @@ urlpatterns = patterns('',
     # Django ATC profile storage
     url(r'^api/v1/profiles/', include('atc_profile_storage.urls')),
     url(r'^$', RedirectView.as_view(url='/atc_demo_ui/', permanent=False)),
-)
+]
 ```
 
 Finally, let's update the Django DB:

--- a/atc/django-atc-api/atc_api/urls.py
+++ b/atc/django-atc-api/atc_api/urls.py
@@ -7,12 +7,10 @@
 #  of patent rights can be found in the PATENTS file in the same directory.
 #
 #
-from django.conf.urls import patterns
 from django.conf.urls import url
 from atc_api.views import AtcApi, AuthApi, TokenApi
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url('^shape/$', AtcApi.as_view()),
     url('^shape/'
         '(?P<address>[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})/$',
@@ -23,4 +21,4 @@ urlpatterns = patterns(
         '(?P<address>[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3})/$',
         AuthApi.as_view()),
     url('^token/$', TokenApi.as_view()),
-)
+]

--- a/atc/django-atc-demo-ui/README.md
+++ b/atc/django-atc-demo-ui/README.md
@@ -46,12 +46,12 @@ If you want to have `/` redirecting to `/atc/demo_ui`, you can update `urls.py`
 ...
 from django.views.generic.base import RedirectView
 
-urlpatterns = patterns('',
+urlpatterns = [
     ...
     ...
     url(r'^atc_demo_ui/', include('atc_demo_ui.urls')),
     url(r'^$', RedirectView.as_view(url='/atc_demo_ui/', permanent=False)),
-)
+]
 ```
 
 3. Start the development server

--- a/atc/django-atc-demo-ui/atc_demo_ui/urls.py
+++ b/atc/django-atc-demo-ui/atc_demo_ui/urls.py
@@ -7,11 +7,10 @@
 #  of patent rights can be found in the PATENTS file in the same directory.
 #
 #
-from django.conf.urls import patterns
 from django.conf.urls import url
+from atc_demo_ui.views import index
 
 
-urlpatterns = patterns(
-    '',
-    url(r'^$', 'atc_demo_ui.views.index', name='atc-demo-ui-index'),
-)
+urlpatterns = [
+    url(r'^$', index, name='atc-demo-ui-index'),
+]

--- a/chef/atc/attributes/default.rb
+++ b/chef/atc/attributes/default.rb
@@ -27,7 +27,7 @@ default['atc']['venv']['atcd']['packages'] = {
 
 # 'pyroute2' => {:action => :upgrade, :version => "0.1.12"},
 default['atc']['venv']['atcui']['packages'] = {
-  'django' => { :version => '1.9' },
+  'django' => { :version => '1.10' },
   'gunicorn' => {},
   "file://#{File.join(src_dir, 'atc/atc_thrift/')}" =>
     { :action => :install, :options => '-e' },

--- a/chef/atc/templates/default/django/settings.py.erb
+++ b/chef/atc/templates/default/django/settings.py.erb
@@ -93,6 +93,13 @@ STATICFILES_FINDERS = (
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = '#g^0#9qe7b=$t_=z2-a5_=$=g8+0-gl-_^3rdtn83z8wk%h&@9'
 
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+    },
+]
+
 # List of callables that know how to import templates from various sources.
 TEMPLATE_LOADERS = (
     'django.template.loaders.filesystem.Loader',

--- a/chef/atc/templates/default/django/urls.py.erb
+++ b/chef/atc/templates/default/django/urls.py.erb
@@ -1,5 +1,4 @@
 from django.conf.urls import include
-from django.conf.urls import patterns
 from django.conf.urls import url
 from django.contrib import admin
 from django.views.generic import RedirectView
@@ -9,12 +8,11 @@ from django.conf.urls.static import static
 
 admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
     url(r'^api/v1/', include('atc_api.urls')),
     url(r'^api/v1/profiles/', include('atc_profile_storage.urls')),
     url(r'^$', RedirectView.as_view(url='/atc_demo_ui/', permanent=False)),
     url(r'^atc_demo_ui/', include('atc_demo_ui.urls')),
-)
+]
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
* [django.url.conf.urls.patterns is deprecated](https://docs.djangoproject.com/en/1.10/releases/1.10/#features-removed-in-1-10)
* set up [template
* engines](https://docs.djangoproject.com/en/1.10/topics/templates/#support-for-template-engines)
* bump django 1.10 in chef recipe

Fixes 296