### PR TITLE
Fix header handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.5.1
+FROM golang:latest
 RUN apt-get -y update && apt-get -y install iptables rsyslog && systemctl enable rsyslog && apt-get -y clean
 
 COPY ./utils/docker_entrypoint.sh /

--- a/src/api/atc_connector.go
+++ b/src/api/atc_connector.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"net/url"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/facebook/augmented-traffic-control/src/atc_thrift"
 )
 

--- a/src/atc_thrift/atcd-remote/atcd-remote.go
+++ b/src/atc_thrift/atcd-remote/atcd-remote.go
@@ -7,7 +7,7 @@ import (
 	"atc_thrift"
 	"flag"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 	"math"
 	"net"
 	"net/url"

--- a/src/atc_thrift/atcd.go
+++ b/src/atc_thrift/atcd.go
@@ -6,7 +6,7 @@ package atc_thrift
 import (
 	"bytes"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/src/atc_thrift/constants.go
+++ b/src/atc_thrift/constants.go
@@ -6,7 +6,7 @@ package atc_thrift
 import (
 	"bytes"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/src/atc_thrift/ttypes.go
+++ b/src/atc_thrift/ttypes.go
@@ -6,7 +6,7 @@ package atc_thrift
 import (
 	"bytes"
 	"fmt"
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 )
 
 // (needed to ensure safety because of naive import list construction.)

--- a/src/atcd/main.go
+++ b/src/atcd/main.go
@@ -6,7 +6,7 @@ import (
 	"net"
 	"os"
 
-	"git.apache.org/thrift.git/lib/go/thrift"
+	"github.com/apache/thrift/lib/go/thrift"
 	"github.com/facebook/augmented-traffic-control/src/atc_thrift"
 	"github.com/facebook/augmented-traffic-control/src/daemon"
 	logging "github.com/facebook/augmented-traffic-control/src/log"


### PR DESCRIPTION
net/http use a cananicalized version of http headers, so even though
X_HTTP_REAL_IP was set by the proxy, it ended up being X_http_real_ip,
hence we were failing the check.
Add test case to confirm that if multiple X_HTTP_REAL_IP are given, we
wil fail but log it.

```
--- FAIL: TestGetsProxiedAddr (0.00s)
    utils_test.go:106: Invalid proxy address
panic: runtime error: index out of range [recovered]
    panic: runtime error: index out of range

goroutine 204 [running]:
testing.tRunner.func1(0xc4203bfba0)
    /usr/local/go/src/testing/testing.go:622 +0x29d
panic(0x8ccc00, 0xd542a0)
    /usr/local/go/src/runtime/panic.go:489 +0x2cf
github.com/facebook/augmented-traffic-control/src/api.getProxiedClientAddr(0xc42019edc0,
0xc420161400, 0xe, 0x94312f, 0x7, 0xc42015b140, 0x1a)
    /usr/src/myapp/.gopath/src/github.com/facebook/augmented-traffic-control/src/api/utils.go:184
+0x56e
github.com/facebook/augmented-traffic-control/src/api.TestGetsProxiedAddr.func1(0x94decb,
0x18, 0x94312f, 0x7, 0x0, 0x0, 0x0, 0x0, 0x7f8bf78cec00, 0xc42015b100)
    /usr/src/myapp/.gopath/src/github.com/facebook/augmented-traffic-control/src/api/utils_test.go:87
+0x152
github.com/facebook/augmented-traffic-control/src/api.TestGetsProxiedAddr(0xc4203bfba0)
    /usr/src/myapp/.gopath/src/github.com/facebook/augmented-traffic-control/src/api/utils_test.go:118
+0x288
testing.tRunner(0xc4203bfba0, 0x95e448)
    /usr/local/go/src/testing/testing.go:657 +0x96
created by testing.(*T).Run
    /usr/local/go/src/testing/testing.go:697 +0x2ca
exit status 2
FAIL    github.com/facebook/augmented-traffic-control/src/api   0.058s
Makefile:91: recipe for target 'test-api' failed
make: *** [test-api] Error 1
```
