### PR TITLE
Update Setup.md

### DIFF
--- a/Setup.md
+++ b/Setup.md
@@ -40,13 +40,13 @@ ATC Daemon
 Installation:
 
 ```shell
-pip install atcd
+sudo pip install atcd
 ```
 
 Running `atcd` (as root):
 
 ```shell
-atcd --atcd-lan eth0 --atcd-wan eth1
+sudo atcd --atcd-lan eth0 --atcd-wan eth1
 ```
 
 ATC Interface
@@ -55,7 +55,7 @@ ATC Interface
 Install the ATC API and UI packages:
 
 ```shell
-pip install django-atc-api django-atc-demo-ui django-atc-profile-storage
+sudo pip install django-atc-api django-atc-demo-ui django-atc-profile-storage
 ```
 
 ### Django Webapp Setup


### PR DESCRIPTION
Talked a user through setting up atc. Turns out that pip will silently fail to install the atcd binary to /usr/local/bin if they don't have write permission. Add sudo to the guide so they aren't as confused.