### PR TITLE
Fix build errors

### DIFF
--- a/atc/atcd/atcd/tools/test_secure_access.py
+++ b/atc/atcd/atcd/tools/test_secure_access.py
@@ -47,6 +47,7 @@ def parse_arguments():
     )
     return parser.parse_args()
 
+
 if __name__ == '__main__':
     options = parse_arguments()
     client = getAtcClient()

--- a/atc/atcd/setup.py
+++ b/atc/atcd/setup.py
@@ -40,6 +40,7 @@ def get_version(package):
     init_py = open(os.path.join(package, '__init__.py')).read()
     return re.search("__version__ = ['\"]([^'\"]+)['\"]", init_py).group(1)
 
+
 version = get_version('atcd')
 
 if sys.argv[-1] == 'publish':

--- a/atc/django-atc-api/setup.py
+++ b/atc/django-atc-api/setup.py
@@ -50,6 +50,7 @@ def get_package_data(package):
                           for filename in filenames])
     return {package: filepaths}
 
+
 version = get_version('atc_api')
 
 if sys.argv[-1] == 'publish':

--- a/atc/django-atc-demo-ui/setup.py
+++ b/atc/django-atc-demo-ui/setup.py
@@ -57,6 +57,7 @@ def get_package_data(package):
                           for filename in filenames])
     return {package: filepaths}
 
+
 version = get_version('atc_demo_ui')
 
 if sys.argv[-1] == 'publish':

--- a/atc/django-atc-profile-storage/setup.py
+++ b/atc/django-atc-profile-storage/setup.py
@@ -50,6 +50,7 @@ def get_package_data(package):
                           for filename in filenames])
     return {package: filepaths}
 
+
 version = get_version('atc_profile_storage')
 
 if sys.argv[-1] == 'publish':


### PR DESCRIPTION
Fix build errors

```bash
2.08s$ make python_lint
pep8 atc
python -m flake8 atc
atc/atcd/setup.py:43:1: E305 expected 2 blank lines after class or function definition, found 1
atc/atcd/atcd/tools/test_secure_access.py:50:1: E305 expected 2 blank lines after class or function definition, found 1
atc/django-atc-api/setup.py:53:1: E305 expected 2 blank lines after class or function definition, found 1
atc/django-atc-demo-ui/setup.py:60:1: E305 expected 2 blank lines after class or function definition, found 1
atc/django-atc-profile-storage/setup.py:53:1: E305 expected 2 blank lines after class or function definition, found 1
make: *** [python_lint] Error 1
The command "make python_lint" exited with 2.

```