### PR TITLE
Fix memory leak by cleaning up the gorilla context, via middleware

### DIFF
--- a/src/api/server.go
+++ b/src/api/server.go
@@ -123,8 +123,8 @@ func (srv *Server) setupHandlers() {
 	apir := r.PathPrefix(ROOT_URL).Subrouter()
 	for url, f := range APIURLMap {
 		h := NewHandler(srv, f)
-		apir.HandleFunc(url, h)
-		apir.HandleFunc(url+"/", h)
+		apir.Handle(url, h)
+		apir.Handle(url+"/", h)
 	}
 	r.HandleFunc("/", srv.assets.Index)
 	r.HandleFunc("/static/{folder}/{name}", srv.assets.Asset)

--- a/src/api/utils.go
+++ b/src/api/utils.go
@@ -58,8 +58,8 @@ type HandlerFunc func(http.ResponseWriter, *http.Request) (interface{}, HttpErro
 // internal to this file:
 type errorFunc func(http.ResponseWriter, *http.Request) HttpError
 
-func NewHandler(srv *Server, f HandlerFunc) http.HandlerFunc {
-	return ErrorHandler(ContextHandler(srv, JsonHandler(f)))
+func NewHandler(srv *Server, f HandlerFunc) http.Handler {
+	return context.ClearHandler(ErrorHandler(ContextHandler(srv, JsonHandler(f))))
 }
 
 // Http handler to set context data for requests.


### PR DESCRIPTION
Ran some tests. 10k requests, synchronously, dumping memory after each HTTP request via the runtime package. unpretty graph warning of the first 1000 requests.
![screenshot from 2017-09-02 16-43-06](https://user-images.githubusercontent.com/1443459/29999456-e896bdce-8ffd-11e7-8c68-d6f08a06296e.png)


