### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,6 @@ cd /var/django && python manage.py runserver 0.0.0.0:8000
 [atc_architecture]: https://facebook.github.io/augmented-traffic-control/images/atc_overview.png
 [build-status-image]: https://travis-ci.org/facebook/augmented-traffic-control.svg?branch=master
 [travis]: https://travis-ci.org/facebook/augmented-traffic-control?branch=master
-[pypi-version]: https://pypip.in/version/atcd/badge.svg
+[pypi-version]: https://img.shields.io/pypi/v/atcd.svg
 [pypi]: https://pypi.python.org/pypi/atcd
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-atc-api))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-atc-api`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.